### PR TITLE
Define Marseille venue locations as taxonomy terms

### DIFF
--- a/archetypes/events.md
+++ b/archetypes/events.md
@@ -58,7 +58,7 @@ categories:
   - ""
 
 # Lieu de l'événement - slug du lieu
-# Exemple: "klap-maison-pour-la-danse"
+# Valeurs: klap, la-friche, la-criee, chateau-de-servieres, notre-dame-de-la-garde
 locations:
   - ""
 

--- a/content/events/2026/01/26/vendre-la-meche.fr.md
+++ b/content/events/2026/01/26/vendre-la-meche.fr.md
@@ -13,7 +13,7 @@ startTime: "19:00"
 categories:
   - "danse"
 locations:
-  - "klap-maison-pour-la-danse"
+  - "klap"
 dates:
   - "lundi-26-janvier"
 tags:

--- a/content/events/2026/01/29/exposition-la-releve.fr.md
+++ b/content/events/2026/01/29/exposition-la-releve.fr.md
@@ -29,7 +29,7 @@ description: "Exposition d'art contemporain présentant les œuvres de jeunes ar
 categories:
   - "art"
 locations:
-  - "galerie-chateau-de-servieres"
+  - "chateau-de-servieres"
 dates:
   - "mercredi-29-janvier"
 tags:

--- a/content/locations/chateau-de-servieres/_index.fr.md
+++ b/content/locations/chateau-de-servieres/_index.fr.md
@@ -1,0 +1,19 @@
+---
+title: "Galerie Château de Servières"
+description: "Espace d'art contemporain à Marseille, expositions et événements artistiques."
+
+# Informations du lieu
+address: "19 boulevard Boisson"
+arrondissement: "13004 Marseille"
+website: "https://www.chateaudeservieres.org/"
+type: "Galerie d'art"
+
+# Aliases pour le crawler (variations du nom)
+aliases:
+  - "/locations/galerie-chateau-de-servieres/"
+  - "/locations/servieres/"
+---
+
+La Galerie Château de Servières est un espace d'art contemporain situé dans le 4e arrondissement de Marseille. Installée dans un ancien château du XIXe siècle, elle présente des expositions d'artistes émergents et confirmés.
+
+Le lieu propose également des ateliers, des résidences d'artistes et des événements culturels tout au long de l'année.

--- a/content/locations/galerie-chateau-de-servieres/_index.fr.md
+++ b/content/locations/galerie-chateau-de-servieres/_index.fr.md
@@ -1,4 +1,0 @@
----
-title: "Galerie Château de Servières"
-description: "Espace d'art contemporain à Marseille, expositions et événements artistiques."
----

--- a/content/locations/klap-maison-pour-la-danse/_index.fr.md
+++ b/content/locations/klap-maison-pour-la-danse/_index.fr.md
@@ -1,4 +1,0 @@
----
-title: "KLAP Maison pour la danse"
-description: "Centre chorégraphique national dédié à la danse contemporaine à Marseille."
----

--- a/content/locations/klap/_index.fr.md
+++ b/content/locations/klap/_index.fr.md
@@ -1,0 +1,18 @@
+---
+title: "KLAP Maison pour la danse"
+description: "Centre chorégraphique national dédié à la danse contemporaine à Marseille."
+
+# Informations du lieu
+address: "5 avenue Rostand"
+arrondissement: "13003 Marseille"
+website: "https://www.kelemenis.fr/"
+type: "Salle de spectacle"
+
+# Aliases pour le crawler (variations du nom)
+aliases:
+  - "/locations/klap-maison-pour-la-danse/"
+---
+
+KLAP Maison pour la danse est un centre chorégraphique national situé dans le 3e arrondissement de Marseille. Dirigé par le chorégraphe Michel Kelemenis, ce lieu est dédié à la création, la production et la diffusion de la danse contemporaine.
+
+Le bâtiment comprend plusieurs studios de danse, un théâtre de 250 places et des espaces de résidence pour les artistes.

--- a/content/locations/la-criee/_index.fr.md
+++ b/content/locations/la-criee/_index.fr.md
@@ -1,4 +1,19 @@
 ---
-title: "La Criée"
-description: "Théâtre National de Marseille, scène majeure du spectacle vivant."
+title: "La Criée - Théâtre National de Marseille"
+description: "Théâtre National de Marseille, scène majeure du spectacle vivant sur le Vieux-Port."
+
+# Informations du lieu
+address: "30 quai de Rive Neuve"
+arrondissement: "13007 Marseille"
+website: "https://www.theatre-lacriee.com/"
+type: "Théâtre"
+
+# Aliases pour le crawler (variations du nom)
+aliases:
+  - "/locations/theatre-la-criee/"
+  - "/locations/criee/"
 ---
+
+La Criée est le Théâtre National de Marseille, situé sur le Vieux-Port dans l'ancienne criée aux poissons. Ce lieu emblématique de la vie culturelle marseillaise propose une programmation riche en théâtre, danse et musique.
+
+Le théâtre dispose de deux salles : la Grande Salle (800 places) et le Petit Théâtre (280 places), permettant d'accueillir des productions de toutes envergures.

--- a/content/locations/la-friche/_index.fr.md
+++ b/content/locations/la-friche/_index.fr.md
@@ -1,4 +1,19 @@
 ---
-title: "La Friche"
-description: "La Friche la Belle de Mai, espace culturel pluridisciplinaire à Marseille."
+title: "La Friche la Belle de Mai"
+description: "Espace culturel pluridisciplinaire à Marseille, ancienne manufacture de tabac reconvertie."
+
+# Informations du lieu
+address: "41 rue Jobin"
+arrondissement: "13003 Marseille"
+website: "https://www.lafriche.org/"
+type: "Complexe culturel"
+
+# Aliases pour le crawler (variations du nom)
+aliases:
+  - "/locations/friche/"
+  - "/locations/friche-belle-de-mai/"
 ---
+
+La Friche la Belle de Mai est un espace culturel pluridisciplinaire de 45 000 m² situé dans une ancienne manufacture de tabac du 3e arrondissement de Marseille.
+
+Ce lieu emblématique accueille des expositions, concerts, spectacles de danse et de théâtre, projections cinématographiques et événements communautaires. Il abrite également des ateliers d'artistes, des studios de création et plusieurs restaurants.

--- a/content/locations/notre-dame-de-la-garde/_index.fr.md
+++ b/content/locations/notre-dame-de-la-garde/_index.fr.md
@@ -1,4 +1,19 @@
 ---
 title: "Notre-Dame de la Garde"
 description: "Basilique emblématique de Marseille, lieu d'événements communautaires et culturels."
+
+# Informations du lieu
+address: "Rue Fort du Sanctuaire"
+arrondissement: "13006 Marseille"
+website: "https://www.notredamedelagarde.com/"
+type: "Monument historique"
+
+# Aliases pour le crawler (variations du nom)
+aliases:
+  - "/locations/bonne-mere/"
+  - "/locations/ndg/"
 ---
+
+Notre-Dame de la Garde, surnommée « la Bonne Mère » par les Marseillais, est une basilique située au sommet d'une colline de 154 mètres d'altitude dans le 6e arrondissement de Marseille.
+
+Ce monument emblématique offre une vue panoramique sur la ville et la mer. Au-delà de sa fonction religieuse, le site accueille des événements communautaires et culturels tout au long de l'année.


### PR DESCRIPTION
## Summary

Enhance venue locations with comprehensive information and simplified slugs:

| Old Slug | New Slug | Display Name |
|----------|----------|--------------|
| klap-maison-pour-la-danse | klap | KLAP Maison pour la danse |
| galerie-chateau-de-servieres | chateau-de-servieres | Galerie Château de Servières |
| la-friche | la-friche | La Friche la Belle de Mai |
| la-criee | la-criee | La Criée - Théâtre National de Marseille |
| notre-dame-de-la-garde | notre-dame-de-la-garde | Notre-Dame de la Garde |

## New Fields for Each Location

- **address**: Street address
- **arrondissement**: Postal code (13003, 13004, 13006, 13007)
- **website**: Official venue website URL
- **type**: Venue type (Salle de spectacle, Théâtre, Galerie d'art, etc.)
- **aliases**: Redirects from common name variations

## Aliases Enable Flexible URLs

- `/locations/klap-maison-pour-la-danse/` → `/locations/klap/`
- `/locations/friche/` → `/locations/la-friche/`
- `/locations/bonne-mere/` → `/locations/notre-dame-de-la-garde/`
- `/locations/criee/` → `/locations/la-criee/`

## Test plan

- [x] Build site with `hugo --gc --minify` - no errors
- [x] Aliases create redirect pages (32 total)
- [ ] Navigate to `/locations/klap/` - displays KLAP venue page
- [ ] Navigate to `/locations/klap-maison-pour-la-danse/` - redirects to `/locations/klap/`
- [ ] Verify events appear under correct location pages
- [ ] Verify location information (address, website) displays correctly

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)