### PR TITLE
Implement date-based folder structure for event storage

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -32,6 +32,10 @@ enableEmoji = true
   tag = "tags"
   author = "authors"
 
+[permalinks]
+  # Events use date-based URLs: /events/2025/01/26/event-name/
+  events = "/events/:year/:month/:day/:slug/"
+
 [sitemap]
   changefreq = 'daily'
   filename = 'sitemap.xml'

--- a/content/events/_index.fr.md
+++ b/content/events/_index.fr.md
@@ -1,4 +1,37 @@
 ---
 title: "Événements"
 description: "Tous les événements culturels à Marseille : danse, musique, théâtre, art et communauté."
+
+# Cascade defaults for all events in this section
+cascade:
+  # Display settings for event pages
+  showDate: true
+  showReadingTime: false
+  showWordCount: false
+  showAuthor: false
 ---
+
+Bienvenue sur l'agenda culturel de Marseille. Découvrez les événements de la semaine : spectacles de danse, concerts, pièces de théâtre, expositions et activités communautaires.
+
+## Structure des événements
+
+Les événements sont organisés par date dans une structure `/events/YYYY/MM/DD/`:
+
+```
+/content/events/
+├── _index.fr.md
+├── 2026/
+│   └── 01/
+│       ├── 26/
+│       │   └── vendre-la-meche.fr.md
+│       ├── 27/
+│       │   ├── concert-la-friche.fr.md
+│       │   └── theatre-la-criee.fr.md
+│       └── 29/
+│           └── exposition-la-releve.fr.md
+```
+
+Pour créer un nouvel événement:
+```bash
+hugo new events/2026/01/30/nom-evenement.fr.md --kind events
+```


### PR DESCRIPTION
## Summary

Configure Hugo to properly support the date-based folder structure for events (`/content/events/YYYY/MM/DD/`).

## Changes

### Permalink Configuration
Added to `hugo.toml`:
```toml
[permalinks]
  events = "/events/:year/:month/:day/:slug/"
```

This ensures event URLs follow the folder structure:
- `/events/2026/01/26/vendre-la-meche/`
- `/events/2026/01/27/concert-la-friche/`

### Cascade Defaults
Added to `content/events/_index.fr.md`:
- `showDate: true` - Display event date
- `showReadingTime: false` - Not relevant for events
- `showWordCount: false` - Not relevant for events
- `showAuthor: false` - Events don't have authors

### Documentation
Added folder structure documentation and usage instructions to the events section index.

## Test plan

- [x] Build site with `hugo --gc --minify` - no errors
- [x] Verify URLs follow `/events/YYYY/MM/DD/slug/` pattern
- [x] Test `hugo new events/2026/01/30/test.fr.md --kind events` - creates file in correct location
- [ ] Navigate to `/events/` - displays section index with documentation
- [ ] Navigate to `/events/2026/01/26/vendre-la-meche/` - displays event page

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)