### PR TITLE
Build single event detail page with full information, image, and source link

### DIFF
--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -1,0 +1,317 @@
+{{ define "main" }}
+{{/* Event detail page template */}}
+{{ $page := . }}
+{{ $disableImageOptimization := site.Params.disableImageOptimization | default false }}
+
+{{/* French day names (0=Sunday through 6=Saturday) */}}
+{{ $frenchDaysFull := dict
+    "0" "Dimanche"
+    "1" "Lundi"
+    "2" "Mardi"
+    "3" "Mercredi"
+    "4" "Jeudi"
+    "5" "Vendredi"
+    "6" "Samedi"
+}}
+
+{{/* French month names (1-12) */}}
+{{ $frenchMonthsFull := dict
+    "1" "janvier"
+    "2" "février"
+    "3" "mars"
+    "4" "avril"
+    "5" "mai"
+    "6" "juin"
+    "7" "juillet"
+    "8" "août"
+    "9" "septembre"
+    "10" "octobre"
+    "11" "novembre"
+    "12" "décembre"
+}}
+
+{{/* Category color mappings */}}
+{{ $categoryColors := dict
+    "danse" "bg-pink-500 text-white"
+    "musique" "bg-purple-500 text-white"
+    "theatre" "bg-amber-500 text-white"
+    "art" "bg-teal-500 text-white"
+    "communaute" "bg-blue-500 text-white"
+}}
+
+{{/* Get event image */}}
+{{ $imageURL := "" }}
+{{ with $page.Params.image }}
+  {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
+    {{ $imageURL = . }}
+  {{ else if ne . "" }}
+    {{ $img := resources.Get . }}
+    {{ with $img }}
+      {{ if not $disableImageOptimization }}
+        {{ $imageURL = (.Resize "1200x").RelPermalink }}
+      {{ else }}
+        {{ $imageURL = .RelPermalink }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{/* Fallback to page resources */}}
+{{ if eq $imageURL "" }}
+  {{ $images := $page.Resources.ByType "image" }}
+  {{ range slice "*feature*" "*cover*" "*thumbnail*" }}
+    {{ if eq $imageURL "" }}
+      {{ $img := $images.GetMatch . }}
+      {{ with $img }}
+        {{ if not $disableImageOptimization }}
+          {{ $imageURL = ($img.Resize "1200x").RelPermalink }}
+        {{ else }}
+          {{ $imageURL = $img.RelPermalink }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{/* Get event name - fallback to title */}}
+{{ $eventName := $page.Params.name | default $page.Params.eventName | default $page.Title }}
+
+{{/* Format date in full French */}}
+{{ $eventDate := $page.Date }}
+{{ $dayNum := $eventDate.Weekday | int | string }}
+{{ $dayOfMonth := $eventDate.Day }}
+{{ $monthNum := $eventDate.Month | int | string }}
+{{ $year := $eventDate.Year }}
+{{ $dayName := index $frenchDaysFull $dayNum }}
+{{ $monthName := index $frenchMonthsFull $monthNum }}
+{{ $fullDate := printf "%s %d %s %d" $dayName $dayOfMonth $monthName $year }}
+
+{{/* Get start time */}}
+{{ $startTime := $page.Params.startTime | default "" }}
+
+{{/* Get event URL */}}
+{{ $eventURL := $page.Params.eventURL | default $page.Params.url | default "" }}
+
+{{/* Multi-day indicator */}}
+{{ $dayOf := $page.Params.dayOf | default "" }}
+{{ $eventGroupId := $page.Params.eventGroupId | default "" }}
+
+<article class="event-detail max-w-4xl mx-auto">
+  {{/* Back navigation */}}
+  <nav class="mb-6">
+    <a href="/" class="inline-flex items-center gap-2 text-sm font-medium text-neutral-600 hover:text-primary-500 dark:text-neutral-400 dark:hover:text-primary-400 transition-colors">
+      <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+      </svg>
+      Retour aux événements
+    </a>
+  </nav>
+
+  {{/* Hero image section */}}
+  <div class="relative mb-8 overflow-hidden rounded-2xl">
+    {{ if ne $imageURL "" }}
+      <div class="aspect-[21/9] w-full">
+        <img
+          src="{{ $imageURL }}"
+          alt="{{ $eventName }}"
+          class="h-full w-full object-cover"
+        />
+      </div>
+    {{ else }}
+      {{/* Placeholder hero */}}
+      <div class="aspect-[21/9] w-full bg-gradient-to-br from-neutral-200 to-neutral-300 dark:from-neutral-700 dark:to-neutral-800 flex items-center justify-center">
+        <svg class="h-24 w-24 text-neutral-400 dark:text-neutral-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        </svg>
+      </div>
+    {{ end }}
+  </div>
+
+  {{/* Main content */}}
+  <div class="px-4 sm:px-0">
+    {{/* Category badges */}}
+    {{ with $page.Params.categories }}
+      <div class="mb-4 flex flex-wrap gap-2">
+        {{ range . }}
+          {{ $categorySlug := . }}
+          {{ $categoryTitle := "" }}
+          {{ $categoryColor := "bg-neutral-500 text-white" }}
+          {{ with site.GetPage (printf "/categories/%s" $categorySlug) }}
+            {{ $categoryTitle = .Title }}
+          {{ end }}
+          {{ if eq $categoryTitle "" }}
+            {{ $categoryTitle = $categorySlug | title }}
+          {{ end }}
+          {{ with index $categoryColors $categorySlug }}
+            {{ $categoryColor = . }}
+          {{ end }}
+          <a href="{{ printf "/categories/%s/" $categorySlug }}" class="inline-flex items-center rounded-full px-4 py-1.5 text-sm font-semibold {{ $categoryColor }} hover:opacity-90 transition-opacity">
+            {{ $categoryTitle }}
+          </a>
+        {{ end }}
+      </div>
+    {{ end }}
+
+    {{/* Event title */}}
+    <h1 class="text-3xl sm:text-4xl font-extrabold text-neutral-900 dark:text-neutral-100 mb-6">
+      {{ $eventName }}
+    </h1>
+
+    {{/* Event metadata */}}
+    <div class="mb-8 space-y-3">
+      {{/* Location */}}
+      {{ with $page.Params.locations }}
+        {{ $locationSlug := index . 0 }}
+        {{ $locationTitle := "" }}
+        {{ $locationAddress := "" }}
+        {{ with site.GetPage (printf "/locations/%s" $locationSlug) }}
+          {{ $locationTitle = .Title }}
+          {{ $locationAddress = .Params.address }}
+          {{ with .Params.arrondissement }}
+            {{ $locationAddress = printf "%s, %s" $locationAddress . }}
+          {{ end }}
+        {{ end }}
+        {{ if eq $locationTitle "" }}
+          {{ $locationTitle = $locationSlug | humanize | title }}
+        {{ end }}
+        <div class="flex items-start gap-3 text-neutral-700 dark:text-neutral-300">
+          <svg class="h-6 w-6 flex-shrink-0 text-neutral-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+          <div>
+            <a href="{{ printf "/locations/%s/" $locationSlug }}" class="font-semibold hover:text-primary-500 dark:hover:text-primary-400 transition-colors">
+              {{ $locationTitle }}
+            </a>
+            {{ if ne $locationAddress "" }}
+              <p class="text-sm text-neutral-500 dark:text-neutral-400">{{ $locationAddress }}</p>
+            {{ end }}
+          </div>
+        </div>
+      {{ end }}
+
+      {{/* Date */}}
+      <div class="flex items-center gap-3 text-neutral-700 dark:text-neutral-300">
+        <svg class="h-6 w-6 flex-shrink-0 text-neutral-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        </svg>
+        <span class="font-semibold">{{ $fullDate }}</span>
+      </div>
+
+      {{/* Start time */}}
+      {{ if ne $startTime "" }}
+        <div class="flex items-center gap-3 text-neutral-700 dark:text-neutral-300">
+          <svg class="h-6 w-6 flex-shrink-0 text-neutral-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span class="font-semibold text-lg">{{ $startTime }}</span>
+        </div>
+      {{ end }}
+    </div>
+
+    {{/* Multi-day navigation */}}
+    {{ if ne $eventGroupId "" }}
+      {{ $relatedPages := where site.RegularPages "Params.eventGroupId" $eventGroupId }}
+      {{ if gt (len $relatedPages) 1 }}
+        <div class="mb-8 p-4 rounded-xl bg-neutral-100 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700">
+          {{ if ne $dayOf "" }}
+            <p class="text-sm font-semibold text-neutral-900 dark:text-neutral-100 mb-1">{{ $dayOf }}</p>
+          {{ end }}
+          <p class="text-sm text-neutral-600 dark:text-neutral-400 mb-3">
+            Voir les autres dates de cet événement :
+          </p>
+          <div class="flex flex-wrap gap-2">
+            {{ range $relatedPages.ByDate }}
+              {{ if eq .Permalink $page.Permalink }}
+                <span class="px-4 py-1.5 text-sm font-medium rounded-full bg-primary-500 text-white">
+                  {{ .Params.dayOf | default (dateFormat "2 January" .Date) }}
+                </span>
+              {{ else }}
+                <a href="{{ .RelPermalink }}" class="px-4 py-1.5 text-sm font-medium rounded-full border border-primary-400 text-primary-600 hover:bg-primary-100 dark:border-primary-500 dark:text-primary-400 dark:hover:bg-primary-900/50 transition-colors">
+                  {{ .Params.dayOf | default (dateFormat "2 January" .Date) }}
+                </a>
+              {{ end }}
+            {{ end }}
+          </div>
+        </div>
+      {{ end }}
+    {{ end }}
+
+    {{/* Description / Content */}}
+    {{ if or .Content (ne ($page.Params.description | default "") "") }}
+      <div class="mb-8">
+        <h2 class="text-xl font-bold text-neutral-900 dark:text-neutral-100 mb-4 pb-2 border-b border-neutral-200 dark:border-neutral-700">
+          Description
+        </h2>
+        <div class="prose prose-neutral dark:prose-invert max-w-none">
+          {{ if .Content }}
+            {{ .Content }}
+          {{ else }}
+            <p>{{ $page.Params.description }}</p>
+          {{ end }}
+        </div>
+      </div>
+    {{ end }}
+
+    {{/* Source link */}}
+    {{ if ne $eventURL "" }}
+      <div class="mb-8">
+        <h2 class="text-xl font-bold text-neutral-900 dark:text-neutral-100 mb-4 pb-2 border-b border-neutral-200 dark:border-neutral-700">
+          Source
+        </h2>
+        <a href="{{ $eventURL }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 px-4 py-3 rounded-lg bg-neutral-100 hover:bg-neutral-200 dark:bg-neutral-800 dark:hover:bg-neutral-700 transition-colors group">
+          <svg class="h-5 w-5 text-neutral-500 group-hover:text-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+          </svg>
+          <span class="text-neutral-700 dark:text-neutral-300">
+            Voir sur le site original
+          </span>
+          <span class="text-sm text-neutral-500 dark:text-neutral-400">
+            {{ $eventURL | replaceRE "^https?://(www\\.)?" "" | replaceRE "/.*$" "" }}
+          </span>
+        </a>
+      </div>
+    {{ end }}
+
+    {{/* Back to events button */}}
+    <div class="mt-12 mb-8 text-center">
+      <a href="/" class="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-primary-500 text-white font-semibold hover:bg-primary-600 transition-colors">
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+        </svg>
+        Retour aux événements
+      </a>
+    </div>
+  </div>
+</article>
+
+{{/* JSON-LD structured data for SEO */}}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Event",
+  "name": {{ $eventName | jsonify }},
+  "startDate": {{ $page.Date.Format "2006-01-02T15:04:05-07:00" | jsonify }},
+  {{ with $page.Params.description }}"description": {{ . | jsonify }},{{ end }}
+  {{ if ne $imageURL "" }}"image": {{ $imageURL | absURL | jsonify }},{{ end }}
+  {{ with $page.Params.locations }}
+    {{ $locationSlug := index . 0 }}
+    {{ with site.GetPage (printf "/locations/%s" $locationSlug) }}
+  "location": {
+    "@type": "Place",
+    "name": {{ .Title | jsonify }}{{ with .Params.address }},
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": {{ . | jsonify }}{{ with $.Params.arrondissement }},
+      "addressLocality": "Marseille",
+      "postalCode": {{ (index (split . " ") 0) | jsonify }}{{ end }}
+    }{{ end }}
+  },
+    {{ end }}
+  {{ end }}
+  {{ if ne $eventURL "" }}"url": {{ $eventURL | jsonify }},{{ end }}
+  "eventStatus": "https://schema.org/EventScheduled",
+  "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode"
+}
+</script>
+{{ end }}


### PR DESCRIPTION
## Summary

- Create `layouts/events/single.html` template for comprehensive event display
- Display hero image section with placeholder fallback for events without images
- Show category badges prominently with links to taxonomy pages
- Display location with full address and link to location taxonomy page
- Format date in full French format (e.g., "Dimanche 26 janvier 2026")
- Show start time prominently
- Implement multi-day event navigation showing links to other days in series
- Render event description/content with markdown support
- Add source section with external link to original event page (opens in new tab)
- Include back navigation to return to homepage
- Add JSON-LD structured data for SEO

## Test plan

- [ ] Verify page displays all event front matter fields
- [ ] Confirm event image shows as hero (with fallback placeholder)
- [ ] Check category badges link to category taxonomy pages
- [ ] Verify location links to location taxonomy page and shows address
- [ ] Confirm date displays in full French format
- [ ] Test markdown content renders correctly
- [ ] Verify external source link opens in new tab with proper rel attributes
- [ ] Test multi-day events show navigation to other days
- [ ] Confirm back link returns to homepage
- [ ] Verify JSON-LD structured data is present

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)