### PR TITLE
Configure French date and time display throughout the application

### DIFF
--- a/config/_default/languages.fr.toml
+++ b/config/_default/languages.fr.toml
@@ -8,7 +8,9 @@ title = "massalia.events"
   displayName = "FR"
   isoCode = "fr"
   rtl = false
-  dateFormat = "2 January 2006"
+  # Date format is handled by custom French date partial
+  # See layouts/partials/functions/french-date.html
+  dateFormat = ":date_long"
   # logo = "img/logo.png"
   # secondaryLogo = "img/secondary-logo.png"
   # description = "Un agrégateur crée par vibcoding d'événements culturels, artistiques, musicaux et de concerts à Marseille.

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -224,11 +224,11 @@
             {{ range $relatedPages.ByDate }}
               {{ if eq .Permalink $page.Permalink }}
                 <span class="px-4 py-1.5 text-sm font-medium rounded-full bg-primary-500 text-white">
-                  {{ .Params.dayOf | default (dateFormat "2 January" .Date) }}
+                  {{ .Params.dayOf | default (partial "functions/french-date.html" (dict "date" .Date "format" "day-month")) }}
                 </span>
               {{ else }}
                 <a href="{{ .RelPermalink }}" class="px-4 py-1.5 text-sm font-medium rounded-full border border-primary-400 text-primary-600 hover:bg-primary-100 dark:border-primary-500 dark:text-primary-400 dark:hover:bg-primary-900/50 transition-colors">
-                  {{ .Params.dayOf | default (dateFormat "2 January" .Date) }}
+                  {{ .Params.dayOf | default (partial "functions/french-date.html" (dict "date" .Date "format" "day-month")) }}
                 </a>
               {{ end }}
             {{ end }}

--- a/layouts/partials/functions/date.html
+++ b/layouts/partials/functions/date.html
@@ -1,0 +1,5 @@
+{{/*
+  Override Blowfish theme's date.html to use French locale formatting
+  This partial is called by the theme for article dates
+*/}}
+{{ return partial "functions/french-date.html" (dict "date" . "format" "medium") }}

--- a/layouts/partials/functions/french-date.html
+++ b/layouts/partials/functions/french-date.html
@@ -1,0 +1,90 @@
+{{/*
+  French date formatting partial
+  Usage: {{ partial "functions/french-date.html" (dict "date" .Date "format" "long") }}
+
+  Formats:
+  - "long": Dimanche 26 janvier 2026
+  - "medium": 26 janvier 2026
+  - "short": 26 jan
+  - "day-month": 26 janvier
+  - "numeric": 26/01/2026
+*/}}
+
+{{ $date := .date }}
+{{ $format := .format | default "medium" }}
+
+{{/* French day names (0=Sunday through 6=Saturday) */}}
+{{ $frenchDaysFull := dict
+    "0" "Dimanche"
+    "1" "Lundi"
+    "2" "Mardi"
+    "3" "Mercredi"
+    "4" "Jeudi"
+    "5" "Vendredi"
+    "6" "Samedi"
+}}
+
+{{/* French month names (1-12) - full */}}
+{{ $frenchMonthsFull := dict
+    "1" "janvier"
+    "2" "février"
+    "3" "mars"
+    "4" "avril"
+    "5" "mai"
+    "6" "juin"
+    "7" "juillet"
+    "8" "août"
+    "9" "septembre"
+    "10" "octobre"
+    "11" "novembre"
+    "12" "décembre"
+}}
+
+{{/* French month names (1-12) - abbreviated */}}
+{{ $frenchMonthsShort := dict
+    "1" "jan"
+    "2" "fév"
+    "3" "mar"
+    "4" "avr"
+    "5" "mai"
+    "6" "juin"
+    "7" "juil"
+    "8" "août"
+    "9" "sep"
+    "10" "oct"
+    "11" "nov"
+    "12" "déc"
+}}
+
+{{ $dayNum := $date.Weekday | int | string }}
+{{ $dayOfMonth := $date.Day }}
+{{ $monthNum := $date.Month | int | string }}
+{{ $year := $date.Year }}
+
+{{ $dayName := index $frenchDaysFull $dayNum }}
+{{ $monthNameFull := index $frenchMonthsFull $monthNum }}
+{{ $monthNameShort := index $frenchMonthsShort $monthNum }}
+
+{{ $result := "" }}
+
+{{ if eq $format "long" }}
+  {{/* Dimanche 26 janvier 2026 */}}
+  {{ $result = printf "%s %d %s %d" $dayName $dayOfMonth $monthNameFull $year }}
+{{ else if eq $format "medium" }}
+  {{/* 26 janvier 2026 */}}
+  {{ $result = printf "%d %s %d" $dayOfMonth $monthNameFull $year }}
+{{ else if eq $format "short" }}
+  {{/* 26 jan */}}
+  {{ $result = printf "%d %s" $dayOfMonth $monthNameShort }}
+{{ else if eq $format "day-month" }}
+  {{/* 26 janvier */}}
+  {{ $result = printf "%d %s" $dayOfMonth $monthNameFull }}
+{{ else if eq $format "numeric" }}
+  {{/* 26/01/2026 */}}
+  {{ $result = $date.Format "02/01/2006" }}
+{{ else }}
+  {{/* Default to medium */}}
+  {{ $result = printf "%d %s %d" $dayOfMonth $monthNameFull $year }}
+{{ end }}
+
+{{ return $result }}

--- a/layouts/partials/multiday-nav.html
+++ b/layouts/partials/multiday-nav.html
@@ -18,12 +18,12 @@
       {{ range $relatedPages.ByDate }}
         {{ if eq .Permalink $currentPage.Permalink }}
           <span class="px-3 py-1 text-sm rounded-full bg-primary-500 text-white">
-            {{ .Params.dayOf | default (dateFormat "2 January" .Date) }}
+            {{ .Params.dayOf | default (partial "functions/french-date.html" (dict "date" .Date "format" "day-month")) }}
           </span>
         {{ else }}
           <a href="{{ .Permalink }}"
              class="px-3 py-1 text-sm rounded-full border border-primary-400 text-primary-600 hover:bg-primary-100 dark:border-primary-600 dark:text-primary-400 dark:hover:bg-primary-900">
-            {{ .Params.dayOf | default (dateFormat "2 January" .Date) }}
+            {{ .Params.dayOf | default (partial "functions/french-date.html" (dict "date" .Date "format" "day-month")) }}
           </a>
         {{ end }}
       {{ end }}


### PR DESCRIPTION
## Summary

- Create reusable French date formatting partial
- Override theme's date partial to use French localization
- Update templates to display dates in French format

## Changes

### New files
- `layouts/partials/functions/french-date.html` - Reusable French date formatter
- `layouts/partials/functions/date.html` - Override theme's date partial

### Updated files
- `layouts/partials/multiday-nav.html` - Use French dates
- `layouts/events/single.html` - Use French dates in multi-day section
- `config/_default/languages.fr.toml` - Update date format config

## French date formats supported

| Format | Example |
|--------|---------|
| long | Vendredi 6 février 2026 |
| medium | 6 février 2026 |
| short | 6 fév |
| day-month | 6 février |
| numeric | 06/02/2026 |

## Test plan

- [ ] Verify dates display with French month names (janvier, février, etc.)
- [ ] Check dates display with French day names where applicable
- [ ] Confirm event detail page shows "Vendredi 6 février 2026" format
- [ ] Test homepage event cards show abbreviated French dates
- [ ] Verify multi-day navigation shows French dates
- [ ] Ensure RSS/sitemap retain ISO8601 formats (unchanged)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)