### PR TITLE
Create selection criteria document for event inclusion decisions

### DIFF
--- a/crawler/config/selection-criteria.yaml
+++ b/crawler/config/selection-criteria.yaml
@@ -1,0 +1,296 @@
+# Selection Criteria for Massalia Events Crawler
+# ==============================================
+# This document defines which events should be included in the calendar.
+# It is continuously refined based on crawling results.
+#
+# Events are evaluated against these criteria before being added.
+# Rejected events are logged but not saved.
+
+version: "1.0"
+last_updated: "2026-01-26"
+
+# ============================================================================
+# Geographic Scope
+# ============================================================================
+# Focus on Marseille and nearby cultural venues
+
+geography:
+  # Primary location - events must be in or near this city
+  required_location: "Marseille"
+
+  # Nearby cities/areas to include
+  include_nearby:
+    - "Aix-en-Provence"
+    - "Aubagne"
+    - "Cassis"
+    - "La Ciotat"
+    - "Martigues"
+    - "Vitrolles"
+    - "Istres"
+    - "Salon-de-Provence"
+
+  # Locations to explicitly exclude (if detected)
+  exclude_locations:
+    - "Paris"
+    - "Lyon"
+    - "Nice"
+    - "Toulouse"
+    - "Bordeaux"
+    - "Lille"
+    - "Strasbourg"
+    - "Nantes"
+
+  # Keywords that indicate local events (positive signal)
+  local_keywords:
+    - "marseille"
+    - "13001"
+    - "13002"
+    - "13003"
+    - "13004"
+    - "13005"
+    - "13006"
+    - "13007"
+    - "13008"
+    - "13009"
+    - "13010"
+    - "13011"
+    - "13012"
+    - "13013"
+    - "13014"
+    - "13015"
+    - "13016"
+    - "bouches-du-rhône"
+    - "vieux-port"
+    - "la friche"
+    - "mucem"
+
+# ============================================================================
+# Date Constraints
+# ============================================================================
+# Only import events within a reasonable time window
+
+dates:
+  # Minimum days ahead (0 = include today)
+  min_days_ahead: 0
+
+  # Maximum days ahead (don't import events too far in future)
+  max_days_ahead: 90
+
+  # Automatically exclude past events
+  exclude_past: true
+
+# ============================================================================
+# Event Type Filters
+# ============================================================================
+# Define which types of events to include or exclude
+
+event_types:
+  # Event types/categories to include
+  include:
+    - "concert"
+    - "spectacle"
+    - "exposition"
+    - "théâtre"
+    - "theatre"
+    - "danse"
+    - "festival"
+    - "vernissage"
+    - "performance"
+    - "projection"
+    - "cinéma"
+    - "musique"
+    - "art"
+    - "bal"
+    - "soirée"
+    - "fête"
+    - "carnaval"
+    - "opéra"
+    - "cirque"
+    - "humour"
+    - "one man show"
+
+  # Event types to exclude (educational, professional, etc.)
+  exclude:
+    - "formation"
+    - "cours"
+    - "stage professionnel"
+    - "conférence professionnelle"
+    - "séminaire"
+    - "réunion"
+    - "assemblée générale"
+    - "salon professionnel"
+    - "job dating"
+    - "recrutement"
+
+# ============================================================================
+# Keyword Filters
+# ============================================================================
+# Fine-grained control using keyword matching
+
+keywords:
+  # Positive keywords - boost inclusion likelihood
+  # Events containing these are more likely to be included
+  positive:
+    - "gratuit"
+    - "entrée libre"
+    - "free"
+    - "vernissage"
+    - "première"
+    - "avant-première"
+    - "ouverture"
+    - "inauguration"
+    - "festival"
+    - "live"
+    - "en direct"
+
+  # Negative keywords - trigger exclusion
+  # Events containing these will be rejected
+  negative:
+    - "complet"
+    - "sold out"
+    - "annulé"
+    - "cancelled"
+    - "reporté"
+    - "postponed"
+    - "privé"
+    - "private"
+    - "réservé aux adhérents"
+    - "membres uniquement"
+    - "sur invitation"
+    - "invitation only"
+    - "fermé"
+    - "closed"
+
+# ============================================================================
+# Required Fields
+# ============================================================================
+# Events must have these fields to be valid
+
+required_fields:
+  - "name"
+  - "date"
+
+# Optional but recommended fields
+recommended_fields:
+  - "location"
+  - "description"
+  - "url"
+
+# ============================================================================
+# Category Mapping
+# ============================================================================
+# Map source categories to our standard taxonomy
+# Standard categories: danse, musique, theatre, art, communaute
+
+category_mapping:
+  # Default category if no match found
+  default: "communaute"
+
+  # Explicit mappings (source category → our category)
+  mappings:
+    # Music
+    "concert": "musique"
+    "musique": "musique"
+    "music": "musique"
+    "dj": "musique"
+    "dj set": "musique"
+    "électro": "musique"
+    "electro": "musique"
+    "jazz": "musique"
+    "rock": "musique"
+    "hip-hop": "musique"
+    "rap": "musique"
+    "classique": "musique"
+    "opéra": "musique"
+    "chorale": "musique"
+
+    # Theatre
+    "spectacle": "theatre"
+    "théâtre": "theatre"
+    "theatre": "theatre"
+    "comédie": "theatre"
+    "tragédie": "theatre"
+    "one man show": "theatre"
+    "humour": "theatre"
+    "stand-up": "theatre"
+    "cirque": "theatre"
+    "marionnettes": "theatre"
+    "conte": "theatre"
+
+    # Dance
+    "danse": "danse"
+    "dance": "danse"
+    "ballet": "danse"
+    "contemporain": "danse"
+    "hip hop": "danse"
+    "flamenco": "danse"
+    "tango": "danse"
+    "salsa": "danse"
+    "bal": "danse"
+
+    # Art
+    "exposition": "art"
+    "expo": "art"
+    "art": "art"
+    "vernissage": "art"
+    "galerie": "art"
+    "musée": "art"
+    "photographie": "art"
+    "photo": "art"
+    "peinture": "art"
+    "sculpture": "art"
+    "installation": "art"
+    "street art": "art"
+    "cinéma": "art"
+    "projection": "art"
+    "film": "art"
+
+    # Community
+    "festival": "communaute"
+    "fête": "communaute"
+    "marché": "communaute"
+    "brocante": "communaute"
+    "vide-grenier": "communaute"
+    "carnaval": "communaute"
+    "défilé": "communaute"
+    "atelier": "communaute"
+    "workshop": "communaute"
+    "rencontre": "communaute"
+    "conférence": "communaute"
+    "débat": "communaute"
+    "lecture": "communaute"
+
+# ============================================================================
+# Examples (for documentation)
+# ============================================================================
+# These are examples to illustrate the criteria, not used in code
+
+examples:
+  included:
+    - event: "Concert Jazz à La Friche"
+      reason: "Music event at known Marseille venue"
+
+    - event: "Exposition La Relève au MUCEM"
+      reason: "Art exhibition at Marseille museum"
+
+    - event: "Festival de danse contemporaine"
+      reason: "Dance event, positive category match"
+
+    - event: "Vernissage gratuit - Galerie du Panier"
+      reason: "Free art event with positive keywords"
+
+  excluded:
+    - event: "Formation Python pour débutants"
+      reason: "Contains excluded type 'formation'"
+
+    - event: "Soirée privée au Château"
+      reason: "Contains negative keyword 'privé'"
+
+    - event: "Concert à Paris - Olympia"
+      reason: "Outside geographic scope (Paris)"
+
+    - event: "Spectacle complet"
+      reason: "Contains negative keyword 'complet'"
+
+    - event: "Conférence professionnelle RH"
+      reason: "Professional conference, excluded type"

--- a/crawler/src/selection.py
+++ b/crawler/src/selection.py
@@ -1,0 +1,391 @@
+"""Selection criteria for filtering events."""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import yaml
+
+from .logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class SelectionError(Exception):
+    """Raised when selection criteria configuration is invalid."""
+
+    pass
+
+
+@dataclass
+class SelectionResult:
+    """Result of evaluating an event against selection criteria."""
+
+    accepted: bool
+    reason: str
+    criteria_matched: str = ""  # Which criteria triggered the decision
+
+
+@dataclass
+class GeographyConfig:
+    """Geographic scope configuration."""
+
+    required_location: str = "Marseille"
+    include_nearby: list[str] = field(default_factory=list)
+    exclude_locations: list[str] = field(default_factory=list)
+    local_keywords: list[str] = field(default_factory=list)
+
+
+@dataclass
+class DatesConfig:
+    """Date constraints configuration."""
+
+    min_days_ahead: int = 0
+    max_days_ahead: int = 90
+    exclude_past: bool = True
+
+
+@dataclass
+class EventTypesConfig:
+    """Event type filters configuration."""
+
+    include: list[str] = field(default_factory=list)
+    exclude: list[str] = field(default_factory=list)
+
+
+@dataclass
+class KeywordsConfig:
+    """Keyword filters configuration."""
+
+    positive: list[str] = field(default_factory=list)
+    negative: list[str] = field(default_factory=list)
+
+
+@dataclass
+class CategoryMappingConfig:
+    """Category mapping configuration."""
+
+    default: str = "communaute"
+    mappings: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class SelectionCriteria:
+    """
+    Selection criteria for filtering events.
+
+    Defines rules for which events should be included in the calendar.
+    Events are evaluated against geography, dates, event types,
+    keywords, and required fields.
+    """
+
+    version: str = "1.0"
+    geography: GeographyConfig = field(default_factory=GeographyConfig)
+    dates: DatesConfig = field(default_factory=DatesConfig)
+    event_types: EventTypesConfig = field(default_factory=EventTypesConfig)
+    keywords: KeywordsConfig = field(default_factory=KeywordsConfig)
+    required_fields: list[str] = field(default_factory=lambda: ["name", "date"])
+    recommended_fields: list[str] = field(default_factory=list)
+    category_mapping: CategoryMappingConfig = field(default_factory=CategoryMappingConfig)
+
+    def evaluate(
+        self,
+        name: str,
+        date: datetime | None,
+        location: str = "",
+        description: str = "",
+        category: str = "",
+        url: str = "",
+    ) -> SelectionResult:
+        """
+        Evaluate an event against all selection criteria.
+
+        Args:
+            name: Event name/title
+            date: Event date/time
+            location: Event location/venue
+            description: Event description
+            category: Event category/type
+            url: Event URL
+
+        Returns:
+            SelectionResult with accepted status and reason
+        """
+        # Combine all text for keyword matching
+        all_text = " ".join([
+            name or "",
+            location or "",
+            description or "",
+            category or "",
+        ]).lower()
+
+        # 1. Check required fields
+        result = self._check_required_fields(name, date, location)
+        if not result.accepted:
+            return result
+
+        # 2. Check negative keywords (exclusion)
+        result = self._check_negative_keywords(all_text)
+        if not result.accepted:
+            return result
+
+        # 3. Check excluded event types
+        result = self._check_excluded_types(all_text, category)
+        if not result.accepted:
+            return result
+
+        # 4. Check excluded locations
+        result = self._check_excluded_locations(location, all_text)
+        if not result.accepted:
+            return result
+
+        # 5. Check date constraints
+        if date:
+            result = self._check_date_constraints(date)
+            if not result.accepted:
+                return result
+
+        # 6. Check included event types (at least one should match for non-empty list)
+        if self.event_types.include:
+            result = self._check_included_types(all_text, category)
+            if not result.accepted:
+                return result
+
+        # Event passed all criteria
+        positive_keywords = self._find_positive_keywords(all_text)
+        if positive_keywords:
+            return SelectionResult(
+                accepted=True,
+                reason=f"Accepted with positive keywords: {', '.join(positive_keywords)}",
+                criteria_matched="positive_keywords",
+            )
+
+        return SelectionResult(
+            accepted=True,
+            reason="Accepted - passed all criteria",
+            criteria_matched="all_criteria",
+        )
+
+    def _check_required_fields(
+        self, name: str, date: datetime | None, location: str
+    ) -> SelectionResult:
+        """Check that required fields are present."""
+        missing = []
+
+        if "name" in self.required_fields and not name:
+            missing.append("name")
+        if "date" in self.required_fields and not date:
+            missing.append("date")
+        if "location" in self.required_fields and not location:
+            missing.append("location")
+
+        if missing:
+            return SelectionResult(
+                accepted=False,
+                reason=f"Missing required fields: {', '.join(missing)}",
+                criteria_matched="required_fields",
+            )
+
+        return SelectionResult(accepted=True, reason="")
+
+    def _check_negative_keywords(self, text: str) -> SelectionResult:
+        """Check for negative keywords that trigger exclusion."""
+        for keyword in self.keywords.negative:
+            if keyword.lower() in text:
+                return SelectionResult(
+                    accepted=False,
+                    reason=f"Contains negative keyword: '{keyword}'",
+                    criteria_matched="negative_keyword",
+                )
+
+        return SelectionResult(accepted=True, reason="")
+
+    def _check_excluded_types(self, text: str, category: str) -> SelectionResult:
+        """Check for excluded event types."""
+        check_text = f"{text} {category}".lower()
+
+        for excluded_type in self.event_types.exclude:
+            if excluded_type.lower() in check_text:
+                return SelectionResult(
+                    accepted=False,
+                    reason=f"Excluded event type: '{excluded_type}'",
+                    criteria_matched="excluded_type",
+                )
+
+        return SelectionResult(accepted=True, reason="")
+
+    def _check_excluded_locations(self, location: str, text: str) -> SelectionResult:
+        """Check for excluded locations."""
+        check_text = f"{location} {text}".lower()
+
+        for excluded_loc in self.geography.exclude_locations:
+            if excluded_loc.lower() in check_text:
+                return SelectionResult(
+                    accepted=False,
+                    reason=f"Excluded location: '{excluded_loc}'",
+                    criteria_matched="excluded_location",
+                )
+
+        return SelectionResult(accepted=True, reason="")
+
+    def _check_date_constraints(self, date: datetime) -> SelectionResult:
+        """Check date is within allowed range."""
+        now = datetime.now()
+        today = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+        # Check if past
+        if self.dates.exclude_past and date < today:
+            return SelectionResult(
+                accepted=False,
+                reason="Event date is in the past",
+                criteria_matched="past_date",
+            )
+
+        # Check min days ahead
+        min_date = today + timedelta(days=self.dates.min_days_ahead)
+        if date < min_date:
+            return SelectionResult(
+                accepted=False,
+                reason=f"Event date is before minimum ({self.dates.min_days_ahead} days ahead)",
+                criteria_matched="min_days",
+            )
+
+        # Check max days ahead
+        max_date = today + timedelta(days=self.dates.max_days_ahead)
+        if date > max_date:
+            return SelectionResult(
+                accepted=False,
+                reason=f"Event date is beyond maximum ({self.dates.max_days_ahead} days ahead)",
+                criteria_matched="max_days",
+            )
+
+        return SelectionResult(accepted=True, reason="")
+
+    def _check_included_types(self, text: str, category: str) -> SelectionResult:
+        """Check that event matches at least one included type."""
+        check_text = f"{text} {category}".lower()
+
+        for included_type in self.event_types.include:
+            if included_type.lower() in check_text:
+                return SelectionResult(accepted=True, reason="")
+
+        # No included type matched
+        return SelectionResult(
+            accepted=False,
+            reason="Does not match any included event type",
+            criteria_matched="no_included_type",
+        )
+
+    def _find_positive_keywords(self, text: str) -> list[str]:
+        """Find positive keywords present in text."""
+        found = []
+        for keyword in self.keywords.positive:
+            if keyword.lower() in text:
+                found.append(keyword)
+        return found
+
+    def map_category(self, source_category: str) -> str:
+        """
+        Map a source category to standard taxonomy.
+
+        Args:
+            source_category: Category from source site
+
+        Returns:
+            Standard category slug
+        """
+        if not source_category:
+            return self.category_mapping.default
+
+        source_lower = source_category.lower()
+
+        # Check explicit mappings
+        for source, target in self.category_mapping.mappings.items():
+            if source.lower() in source_lower:
+                return target
+
+        return self.category_mapping.default
+
+
+def load_selection_criteria(config_path: Path) -> SelectionCriteria:
+    """
+    Load selection criteria from YAML configuration file.
+
+    Args:
+        config_path: Path to selection-criteria.yaml
+
+    Returns:
+        SelectionCriteria instance
+
+    Raises:
+        SelectionError: If configuration is invalid
+    """
+    if not config_path.exists():
+        logger.warning(f"Selection criteria not found: {config_path}, using defaults")
+        return SelectionCriteria()
+
+    logger.info(f"Loading selection criteria from {config_path}")
+
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        raise SelectionError(f"Invalid YAML in selection criteria: {e}") from e
+
+    if not raw:
+        logger.warning("Selection criteria file is empty, using defaults")
+        return SelectionCriteria()
+
+    # Parse configuration sections
+    geography_raw = raw.get("geography", {})
+    geography = GeographyConfig(
+        required_location=geography_raw.get("required_location", "Marseille"),
+        include_nearby=geography_raw.get("include_nearby", []),
+        exclude_locations=geography_raw.get("exclude_locations", []),
+        local_keywords=geography_raw.get("local_keywords", []),
+    )
+
+    dates_raw = raw.get("dates", {})
+    dates = DatesConfig(
+        min_days_ahead=dates_raw.get("min_days_ahead", 0),
+        max_days_ahead=dates_raw.get("max_days_ahead", 90),
+        exclude_past=dates_raw.get("exclude_past", True),
+    )
+
+    event_types_raw = raw.get("event_types", {})
+    event_types = EventTypesConfig(
+        include=event_types_raw.get("include", []),
+        exclude=event_types_raw.get("exclude", []),
+    )
+
+    keywords_raw = raw.get("keywords", {})
+    keywords = KeywordsConfig(
+        positive=keywords_raw.get("positive", []),
+        negative=keywords_raw.get("negative", []),
+    )
+
+    category_raw = raw.get("category_mapping", {})
+    category_mapping = CategoryMappingConfig(
+        default=category_raw.get("default", "communaute"),
+        mappings=category_raw.get("mappings", {}),
+    )
+
+    criteria = SelectionCriteria(
+        version=raw.get("version", "1.0"),
+        geography=geography,
+        dates=dates,
+        event_types=event_types,
+        keywords=keywords,
+        required_fields=raw.get("required_fields", ["name", "date"]),
+        recommended_fields=raw.get("recommended_fields", []),
+        category_mapping=category_mapping,
+    )
+
+    logger.info(
+        f"Loaded selection criteria v{criteria.version}: "
+        f"{len(event_types.include)} included types, "
+        f"{len(event_types.exclude)} excluded types, "
+        f"{len(keywords.negative)} negative keywords"
+    )
+
+    return criteria

--- a/crawler/tests/test_selection.py
+++ b/crawler/tests/test_selection.py
@@ -1,0 +1,370 @@
+"""Tests for selection criteria module."""
+
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+import yaml
+
+from src.selection import (
+    CategoryMappingConfig,
+    DatesConfig,
+    EventTypesConfig,
+    GeographyConfig,
+    KeywordsConfig,
+    SelectionCriteria,
+    SelectionError,
+    SelectionResult,
+    load_selection_criteria,
+)
+
+
+class TestSelectionResult:
+    """Tests for SelectionResult dataclass."""
+
+    def test_accepted_result(self):
+        result = SelectionResult(accepted=True, reason="Passed all criteria")
+        assert result.accepted is True
+        assert result.reason == "Passed all criteria"
+
+    def test_rejected_result(self):
+        result = SelectionResult(
+            accepted=False,
+            reason="Contains negative keyword",
+            criteria_matched="negative_keyword",
+        )
+        assert result.accepted is False
+        assert result.criteria_matched == "negative_keyword"
+
+
+class TestSelectionCriteria:
+    """Tests for SelectionCriteria evaluation."""
+
+    @pytest.fixture
+    def criteria(self):
+        """Create a SelectionCriteria with test configuration."""
+        return SelectionCriteria(
+            geography=GeographyConfig(
+                required_location="Marseille",
+                exclude_locations=["Paris", "Lyon"],
+            ),
+            dates=DatesConfig(
+                min_days_ahead=0,
+                max_days_ahead=90,
+                exclude_past=True,
+            ),
+            event_types=EventTypesConfig(
+                include=["concert", "spectacle", "exposition"],
+                exclude=["formation", "cours"],
+            ),
+            keywords=KeywordsConfig(
+                positive=["gratuit", "vernissage"],
+                negative=["complet", "annulé", "privé"],
+            ),
+            required_fields=["name", "date"],
+            category_mapping=CategoryMappingConfig(
+                default="communaute",
+                mappings={"concert": "musique", "exposition": "art"},
+            ),
+        )
+
+    def test_accept_valid_event(self, criteria):
+        """Test accepting a valid event."""
+        future_date = datetime.now() + timedelta(days=7)
+        result = criteria.evaluate(
+            name="Concert Jazz à Marseille",
+            date=future_date,
+            location="La Friche",
+            description="Un super concert de jazz",
+            category="concert",
+        )
+        assert result.accepted is True
+
+    def test_reject_missing_name(self, criteria):
+        """Test rejecting event without name."""
+        future_date = datetime.now() + timedelta(days=7)
+        result = criteria.evaluate(
+            name="",
+            date=future_date,
+            location="Marseille",
+        )
+        assert result.accepted is False
+        assert "name" in result.reason.lower()
+
+    def test_reject_missing_date(self, criteria):
+        """Test rejecting event without date."""
+        result = criteria.evaluate(
+            name="Test Event",
+            date=None,
+            location="Marseille",
+        )
+        assert result.accepted is False
+        assert "date" in result.reason.lower()
+
+    def test_reject_negative_keyword(self, criteria):
+        """Test rejecting event with negative keyword."""
+        future_date = datetime.now() + timedelta(days=7)
+        result = criteria.evaluate(
+            name="Concert complet",
+            date=future_date,
+            location="Marseille",
+            category="concert",
+        )
+        assert result.accepted is False
+        assert "complet" in result.reason.lower()
+
+    def test_reject_negative_keyword_in_description(self, criteria):
+        """Test rejecting event with negative keyword in description."""
+        future_date = datetime.now() + timedelta(days=7)
+        result = criteria.evaluate(
+            name="Concert Jazz",
+            date=future_date,
+            description="Événement annulé pour cause de météo",
+            category="concert",
+        )
+        assert result.accepted is False
+        assert "annulé" in result.reason.lower()
+
+    def test_reject_excluded_type(self, criteria):
+        """Test rejecting excluded event type."""
+        future_date = datetime.now() + timedelta(days=7)
+        result = criteria.evaluate(
+            name="Formation Python",
+            date=future_date,
+            location="Marseille",
+            category="formation",
+        )
+        assert result.accepted is False
+        assert "formation" in result.reason.lower()
+
+    def test_reject_excluded_location(self, criteria):
+        """Test rejecting event in excluded location."""
+        future_date = datetime.now() + timedelta(days=7)
+        result = criteria.evaluate(
+            name="Concert à Paris",
+            date=future_date,
+            location="Paris",
+            category="concert",
+        )
+        assert result.accepted is False
+        assert "Paris" in result.reason
+
+    def test_reject_past_date(self, criteria):
+        """Test rejecting past event."""
+        past_date = datetime.now() - timedelta(days=7)
+        result = criteria.evaluate(
+            name="Concert passé",
+            date=past_date,
+            location="Marseille",
+            category="concert",
+        )
+        assert result.accepted is False
+        assert "past" in result.reason.lower()
+
+    def test_reject_too_far_future(self, criteria):
+        """Test rejecting event too far in future."""
+        far_future = datetime.now() + timedelta(days=100)
+        result = criteria.evaluate(
+            name="Concert dans 100 jours",
+            date=far_future,
+            location="Marseille",
+            category="concert",
+        )
+        assert result.accepted is False
+        assert "maximum" in result.reason.lower() or "beyond" in result.reason.lower()
+
+    def test_reject_no_matching_type(self, criteria):
+        """Test rejecting event that doesn't match any included type."""
+        future_date = datetime.now() + timedelta(days=7)
+        result = criteria.evaluate(
+            name="Réunion administrative",
+            date=future_date,
+            location="Marseille",
+            category="réunion",
+            description="Une simple réunion",
+        )
+        assert result.accepted is False
+        assert "included event type" in result.reason.lower()
+
+    def test_accept_with_positive_keyword(self, criteria):
+        """Test accepting event with positive keyword noted."""
+        future_date = datetime.now() + timedelta(days=7)
+        result = criteria.evaluate(
+            name="Vernissage gratuit",
+            date=future_date,
+            location="Marseille",
+            category="exposition",
+        )
+        assert result.accepted is True
+        assert "positive keywords" in result.reason.lower()
+
+    def test_category_mapping(self, criteria):
+        """Test category mapping."""
+        assert criteria.map_category("concert") == "musique"
+        assert criteria.map_category("CONCERT live") == "musique"
+        assert criteria.map_category("exposition") == "art"
+        assert criteria.map_category("unknown") == "communaute"
+
+
+class TestDateConstraints:
+    """Tests for date constraint evaluation."""
+
+    @pytest.fixture
+    def criteria_strict_dates(self):
+        """Create criteria with strict date constraints."""
+        return SelectionCriteria(
+            dates=DatesConfig(
+                min_days_ahead=1,
+                max_days_ahead=30,
+                exclude_past=True,
+            ),
+            event_types=EventTypesConfig(include=[]),  # Accept any type
+        )
+
+    def test_reject_today_when_min_days_1(self, criteria_strict_dates):
+        """Test rejecting today's event when min_days_ahead=1."""
+        today = datetime.now().replace(hour=20, minute=0)
+        result = criteria_strict_dates.evaluate(
+            name="Event Today",
+            date=today,
+        )
+        assert result.accepted is False
+
+    def test_accept_tomorrow(self, criteria_strict_dates):
+        """Test accepting tomorrow's event."""
+        tomorrow = datetime.now() + timedelta(days=1)
+        result = criteria_strict_dates.evaluate(
+            name="Event Tomorrow",
+            date=tomorrow,
+        )
+        assert result.accepted is True
+
+    def test_reject_31_days_ahead(self, criteria_strict_dates):
+        """Test rejecting event 31 days ahead when max is 30."""
+        future = datetime.now() + timedelta(days=31)
+        result = criteria_strict_dates.evaluate(
+            name="Event in 31 days",
+            date=future,
+        )
+        assert result.accepted is False
+
+
+class TestKeywordFiltering:
+    """Tests for keyword-based filtering."""
+
+    @pytest.fixture
+    def criteria_keywords(self):
+        """Create criteria with keyword filters."""
+        return SelectionCriteria(
+            keywords=KeywordsConfig(
+                positive=["gratuit", "entrée libre", "première"],
+                negative=["sold out", "complet", "annulé", "privé"],
+            ),
+            event_types=EventTypesConfig(include=[]),
+        )
+
+    def test_reject_sold_out(self, criteria_keywords):
+        """Test rejecting sold out events."""
+        future = datetime.now() + timedelta(days=7)
+        result = criteria_keywords.evaluate(
+            name="Concert - Sold Out",
+            date=future,
+        )
+        assert result.accepted is False
+
+    def test_reject_private_event(self, criteria_keywords):
+        """Test rejecting private events."""
+        future = datetime.now() + timedelta(days=7)
+        result = criteria_keywords.evaluate(
+            name="Soirée",
+            date=future,
+            description="Événement privé sur invitation",
+        )
+        assert result.accepted is False
+
+    def test_accept_free_event(self, criteria_keywords):
+        """Test accepting free events with positive boost."""
+        future = datetime.now() + timedelta(days=7)
+        result = criteria_keywords.evaluate(
+            name="Concert gratuit",
+            date=future,
+        )
+        assert result.accepted is True
+        assert "gratuit" in result.reason.lower()
+
+
+class TestLoadSelectionCriteria:
+    """Tests for loading selection criteria from YAML."""
+
+    @pytest.fixture
+    def temp_dir(self):
+        """Create a temporary directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def test_load_valid_config(self, temp_dir):
+        """Test loading a valid configuration."""
+        config = {
+            "version": "1.0",
+            "geography": {"required_location": "Marseille"},
+            "dates": {"max_days_ahead": 60},
+            "event_types": {"include": ["concert"], "exclude": ["formation"]},
+            "keywords": {"negative": ["annulé"]},
+        }
+
+        config_file = temp_dir / "selection-criteria.yaml"
+        with open(config_file, "w") as f:
+            yaml.dump(config, f)
+
+        criteria = load_selection_criteria(config_file)
+
+        assert criteria.version == "1.0"
+        assert criteria.geography.required_location == "Marseille"
+        assert criteria.dates.max_days_ahead == 60
+        assert "concert" in criteria.event_types.include
+        assert "annulé" in criteria.keywords.negative
+
+    def test_load_nonexistent_returns_defaults(self, temp_dir):
+        """Test that missing file returns default criteria."""
+        nonexistent = temp_dir / "nonexistent.yaml"
+        criteria = load_selection_criteria(nonexistent)
+
+        assert criteria is not None
+        assert criteria.required_fields == ["name", "date"]
+
+    def test_load_empty_returns_defaults(self, temp_dir):
+        """Test that empty file returns default criteria."""
+        config_file = temp_dir / "selection-criteria.yaml"
+        config_file.write_text("")
+
+        criteria = load_selection_criteria(config_file)
+
+        assert criteria is not None
+
+    def test_load_invalid_yaml_raises(self, temp_dir):
+        """Test that invalid YAML raises error."""
+        config_file = temp_dir / "selection-criteria.yaml"
+        config_file.write_text("invalid: yaml: content: [")
+
+        with pytest.raises(SelectionError, match="Invalid YAML"):
+            load_selection_criteria(config_file)
+
+    def test_load_with_category_mapping(self, temp_dir):
+        """Test loading category mapping."""
+        config = {
+            "category_mapping": {
+                "default": "communaute",
+                "mappings": {"concert": "musique", "expo": "art"},
+            }
+        }
+
+        config_file = temp_dir / "selection-criteria.yaml"
+        with open(config_file, "w") as f:
+            yaml.dump(config, f)
+
+        criteria = load_selection_criteria(config_file)
+
+        assert criteria.category_mapping.default == "communaute"
+        assert criteria.map_category("concert") == "musique"
+        assert criteria.map_category("expo") == "art"


### PR DESCRIPTION
## Summary

Implements selection criteria configuration for filtering events as specified in #17. Events are evaluated against these criteria before being added to the calendar.

## Changes

### New Files

**`crawler/config/selection-criteria.yaml`** - Selection rules configuration:
- Geographic scope (Marseille + Aix, Aubagne, Cassis, etc.)
- Date constraints (0-90 days ahead, exclude past)
- Event type include/exclude lists (concert, spectacle, exposition, etc.)
- Keyword filters (positive: gratuit, vernissage; negative: complet, annulé, privé)
- Required fields (name, date)
- Category mapping to standard taxonomy

**`crawler/src/selection.py`** - Selection criteria module:
- `SelectionCriteria` dataclass with `evaluate()` method
- Returns `SelectionResult` with accepted/rejected status and reason
- Validates: required fields, keywords, event types, locations, dates
- Category mapping function

### Updated Files

- `crawler/crawl.py` - Loads selection criteria, adds `--skip-selection` flag
- `crawler/src/crawler.py` - Applies selection in `process_event()`

### Selection Logic

Events are evaluated in this order:
1. **Required fields** - Must have name and date
2. **Negative keywords** - Reject if contains "complet", "annulé", etc.
3. **Excluded event types** - Reject "formation", "cours", etc.
4. **Excluded locations** - Reject Paris, Lyon, etc.
5. **Date constraints** - Must be within 0-90 days
6. **Included event types** - Must match at least one (concert, spectacle, etc.)

### CLI Usage

```bash
# Normal crawl (with selection)
python crawl.py

# Skip selection (include all events for testing)
python crawl.py --skip-selection

# See rejected events in debug mode
python crawl.py --log-level DEBUG
```

## Test Plan

- [x] Run `pytest tests/` - 104 tests passing (25 new selection tests)
- [x] Run `ruff check` - all checks pass
- [ ] Test with `--skip-selection` flag
- [ ] Verify rejected events are logged correctly

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)