### PR TITLE
feat: Build HTML parser with configurable selectors

### DIFF
--- a/crawler/config/sources.yaml
+++ b/crawler/config/sources.yaml
@@ -34,6 +34,15 @@ sources:
     selectors:
       event_list: ".agenda-list"
       event_item: ".event-card"
+      name: "h2, h3, .event-title, .title"
+      date: ".date, .event-date, time"
+      time: ".time, .event-time, .hour"
+      location: ".location, .venue"
+      description: ".description, .excerpt, p"
+      category: ".category, .tag, .type"
+      image: "img"
+      link: "a"
+      tags: ".tag, .label"
     categories_map:
       "Spectacle": "theatre"
       "Concert": "musique"

--- a/crawler/src/parsers/__init__.py
+++ b/crawler/src/parsers/__init__.py
@@ -1,16 +1,49 @@
 """Site-specific event parsers."""
 
+from .base import ConfigurableEventParser, ParsedEvent, SelectorConfig
 from .lafriche import LaFricheParser
 
 PARSERS = {
     "lafriche": LaFricheParser,
+    "generic": ConfigurableEventParser,
 }
 
 
 def get_parser(name: str):
-    """Get parser class by name."""
+    """
+    Get parser class by name.
+
+    Args:
+        name: Parser name (e.g., 'lafriche', 'generic')
+
+    Returns:
+        Parser class
+
+    Raises:
+        ValueError: If parser not found
+    """
     parser_class = PARSERS.get(name.lower())
     if not parser_class:
         available = ", ".join(PARSERS.keys())
         raise ValueError(f"Unknown parser: {name}. Available: {available}")
     return parser_class
+
+
+def list_parsers() -> list[str]:
+    """
+    List all available parser names.
+
+    Returns:
+        List of parser names
+    """
+    return list(PARSERS.keys())
+
+
+__all__ = [
+    "ConfigurableEventParser",
+    "ParsedEvent",
+    "SelectorConfig",
+    "LaFricheParser",
+    "get_parser",
+    "list_parsers",
+]

--- a/crawler/src/parsers/base.py
+++ b/crawler/src/parsers/base.py
@@ -1,0 +1,407 @@
+"""Base parser classes for configurable event extraction."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
+
+from ..logger import get_logger
+from ..models.event import Event
+from ..utils.parser import HTMLParser
+
+if TYPE_CHECKING:
+    from bs4 import Tag
+
+logger = get_logger(__name__)
+
+# Paris timezone for event dates
+PARIS_TZ = ZoneInfo("Europe/Paris")
+
+
+@dataclass
+class ParsedEvent:
+    """
+    Intermediate representation of a parsed event.
+
+    This dataclass holds the raw extracted data before conversion
+    to the final Event model. It preserves the original strings
+    for debugging while also holding parsed values.
+    """
+
+    name: str
+    source_url: str
+    date: datetime | None = None
+    start_time: str | None = None
+    end_time: str | None = None
+    location: str | None = None
+    description: str | None = None
+    category: str | None = None
+    image_url: str | None = None
+    tags: list[str] = field(default_factory=list)
+    raw_date: str = ""  # Original date string for debugging
+    raw_time: str = ""  # Original time string for debugging
+
+
+@dataclass
+class SelectorConfig:
+    """Configuration for CSS selectors used in event parsing."""
+
+    # Container selectors
+    event_list: str = ""  # Container for all events
+    event_item: str = ""  # Individual event item
+
+    # Field selectors (relative to event_item)
+    name: str = "h2, h3, .title, .event-title"
+    date: str = ".date, .event-date, time"
+    time: str = ".time, .event-time, .hour"
+    location: str = ".location, .venue, .event-venue"
+    description: str = ".description, .excerpt, p"
+    category: str = ".category, .tag, .type"
+    image: str = "img"
+    link: str = "a"
+    tags: str = ".tag, .label, .keyword"
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SelectorConfig":
+        """Create SelectorConfig from dictionary."""
+        return cls(
+            event_list=data.get("event_list", ""),
+            event_item=data.get("event_item", ""),
+            name=data.get("name", cls.name),
+            date=data.get("date", cls.date),
+            time=data.get("time", cls.time),
+            location=data.get("location", cls.location),
+            description=data.get("description", cls.description),
+            category=data.get("category", cls.category),
+            image=data.get("image", cls.image),
+            link=data.get("link", cls.link),
+            tags=data.get("tags", cls.tags),
+        )
+
+
+class ConfigurableEventParser:
+    """
+    Configurable event parser using CSS selectors from config.
+
+    This parser extracts events from HTML using selectors defined in
+    the source configuration YAML file. It provides a flexible way
+    to parse different websites without writing custom code.
+
+    For sites with complex structures, extend this class and override
+    specific methods.
+    """
+
+    def __init__(
+        self,
+        config: dict,
+        base_url: str,
+        source_id: str = "unknown",
+        category_map: dict[str, str] | None = None,
+    ):
+        """
+        Initialize configurable parser.
+
+        Args:
+            config: Source configuration dictionary
+            base_url: Base URL for resolving relative links
+            source_id: Unique identifier for this source
+            category_map: Mapping from source categories to standard taxonomy
+        """
+        self.config = config
+        self.base_url = base_url
+        self.source_id = source_id
+        self.category_map = category_map or {}
+
+        # Load selectors from config
+        selectors_dict = config.get("selectors", {})
+        self.selectors = SelectorConfig.from_dict(selectors_dict)
+
+        # Default fallback selectors for event containers
+        self.fallback_item_selectors = [
+            ".event-card",
+            ".event-item",
+            ".event",
+            "article.event",
+            "[class*='event']",
+            ".agenda-item",
+            "[class*='agenda']",
+        ]
+
+    def parse(self, html: str) -> list[ParsedEvent]:
+        """
+        Parse HTML and return list of parsed events.
+
+        Args:
+            html: HTML content to parse
+
+        Returns:
+            List of ParsedEvent objects
+        """
+        parser = HTMLParser(html, self.base_url)
+        events = []
+
+        # Find event containers
+        event_items = self._find_event_items(parser)
+        logger.debug(f"Found {len(event_items)} event items")
+
+        for item in event_items:
+            try:
+                event = self._parse_event_item(item, parser)
+                if event:
+                    events.append(event)
+            except Exception as e:
+                logger.warning(f"Failed to parse event item: {e}")
+
+        return events
+
+    def _find_event_items(self, parser: HTMLParser) -> list["Tag"]:
+        """
+        Find all event item elements on the page.
+
+        Args:
+            parser: HTMLParser instance
+
+        Returns:
+            List of event item elements
+        """
+        # Try configured event list container first
+        if self.selectors.event_list:
+            container = parser.select_one(self.selectors.event_list)
+            if container:
+                if self.selectors.event_item:
+                    return container.select(self.selectors.event_item)
+
+        # Try configured event item selector directly
+        if self.selectors.event_item:
+            items = parser.select(self.selectors.event_item)
+            if items:
+                return items
+
+        # Try fallback selectors
+        for selector in self.fallback_item_selectors:
+            items = parser.select(selector)
+            if items:
+                logger.debug(f"Using fallback selector: {selector}")
+                return items
+
+        logger.warning("No event items found with any selector")
+        return []
+
+    def _parse_event_item(
+        self, item: "Tag", parser: HTMLParser
+    ) -> ParsedEvent | None:
+        """
+        Parse a single event item element.
+
+        Args:
+            item: BeautifulSoup element for event
+            parser: HTMLParser instance for utility methods
+
+        Returns:
+            ParsedEvent or None if parsing failed
+        """
+        # Extract name (required)
+        name = parser.get_text(item, self.selectors.name)
+        if not name:
+            logger.debug("Skipping item without name")
+            return None
+
+        # Extract URL (required for deduplication)
+        event_url = parser.get_link(item, self.selectors.link)
+        if not event_url:
+            logger.debug(f"Skipping event without URL: {name}")
+            return None
+
+        # Extract date
+        raw_date = parser.get_text(item, self.selectors.date)
+        event_date = parser.parse_date(raw_date) if raw_date else None
+
+        # Extract time
+        raw_time = parser.get_text(item, self.selectors.time)
+        event_time = parser.parse_time(raw_time) if raw_time else None
+
+        # Extract other fields
+        location = parser.get_text(item, self.selectors.location)
+        description = parser.get_text(item, self.selectors.description)
+        if description:
+            description = parser.truncate(description, 160)
+
+        category = parser.get_text(item, self.selectors.category)
+        image_url = parser.get_image(item, self.selectors.image)
+        tags = self._extract_tags(item, parser)
+
+        return ParsedEvent(
+            name=name,
+            source_url=event_url,
+            date=event_date,
+            start_time=event_time,
+            location=location,
+            description=description,
+            category=category,
+            image_url=image_url,
+            tags=tags,
+            raw_date=raw_date,
+            raw_time=raw_time,
+        )
+
+    def _extract_tags(self, item: "Tag", parser: HTMLParser) -> list[str]:
+        """
+        Extract tags from event item.
+
+        Args:
+            item: Event item element
+            parser: HTMLParser instance
+
+        Returns:
+            List of tag strings
+        """
+        tags = []
+        tag_elements = item.select(self.selectors.tags)
+
+        for elem in tag_elements:
+            tag_text = elem.get_text().strip()
+            if tag_text and len(tag_text) < 50:
+                tags.append(tag_text.lower())
+
+        return tags[:5]  # Limit to 5 tags
+
+    def to_event(self, parsed: ParsedEvent, default_time: str = "20:00") -> Event:
+        """
+        Convert ParsedEvent to Event model.
+
+        Args:
+            parsed: ParsedEvent to convert
+            default_time: Default time if none parsed
+
+        Returns:
+            Event model instance
+        """
+        # Build datetime with timezone
+        event_datetime = None
+        if parsed.date:
+            time_str = parsed.start_time or default_time
+            try:
+                hour, minute = map(int, time_str.split(":"))
+                event_datetime = parsed.date.replace(
+                    hour=hour, minute=minute, tzinfo=PARIS_TZ
+                )
+            except (ValueError, AttributeError):
+                event_datetime = parsed.date.replace(tzinfo=PARIS_TZ)
+
+        # Map category
+        category = self._map_category(parsed.category)
+
+        # Generate source ID
+        source_id = self._generate_source_id(parsed.source_url)
+
+        # Build locations list
+        locations = []
+        if parsed.location:
+            locations.append(parsed.location)
+
+        return Event(
+            name=parsed.name,
+            event_url=parsed.source_url,
+            start_datetime=event_datetime,
+            description=parsed.description,
+            image=parsed.image_url,
+            categories=[category] if category else [],
+            locations=locations,
+            tags=parsed.tags,
+            source_id=source_id,
+        )
+
+    def _map_category(self, raw_category: str | None) -> str:
+        """
+        Map source category to standard taxonomy.
+
+        Args:
+            raw_category: Category from source
+
+        Returns:
+            Standard category slug
+        """
+        if not raw_category:
+            return "communaute"
+
+        raw_lower = raw_category.lower()
+
+        # Check explicit category map
+        for source_cat, target_cat in self.category_map.items():
+            if source_cat.lower() in raw_lower:
+                return target_cat
+
+        # Default mappings
+        defaults = {
+            "danse": "danse",
+            "dance": "danse",
+            "ballet": "danse",
+            "musique": "musique",
+            "music": "musique",
+            "concert": "musique",
+            "dj": "musique",
+            "theatre": "theatre",
+            "théâtre": "theatre",
+            "spectacle": "theatre",
+            "humour": "theatre",
+            "art": "art",
+            "expo": "art",
+            "exposition": "art",
+            "vernissage": "art",
+            "cinéma": "art",
+            "projection": "art",
+        }
+
+        for key, value in defaults.items():
+            if key in raw_lower:
+                return value
+
+        return "communaute"
+
+    def _generate_source_id(self, url: str) -> str:
+        """
+        Generate unique source ID from URL.
+
+        Args:
+            url: Event URL
+
+        Returns:
+            Source ID string
+        """
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+        path = parsed.path.strip("/")
+
+        # Use last path segment as ID
+        segments = path.split("/")
+        event_id = segments[-1] if segments else path
+
+        return f"{self.source_id}:{event_id}"
+
+    def parse_and_convert(
+        self, html: str, default_time: str = "20:00"
+    ) -> list[Event]:
+        """
+        Parse HTML and return list of Event models.
+
+        Convenience method that combines parse() and to_event().
+
+        Args:
+            html: HTML content to parse
+            default_time: Default time for events without time
+
+        Returns:
+            List of Event objects
+        """
+        parsed_events = self.parse(html)
+        events = []
+
+        for parsed in parsed_events:
+            try:
+                event = self.to_event(parsed, default_time)
+                events.append(event)
+            except Exception as e:
+                logger.warning(f"Failed to convert event '{parsed.name}': {e}")
+
+        return events

--- a/crawler/src/parsers/lafriche.py
+++ b/crawler/src/parsers/lafriche.py
@@ -1,6 +1,5 @@
 """Parser for La Friche Belle de Mai events."""
 
-import re
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
@@ -8,6 +7,7 @@ from ..crawler import BaseCrawler
 from ..logger import get_logger
 from ..models.event import Event
 from ..utils.parser import HTMLParser
+from .base import ConfigurableEventParser
 
 logger = get_logger(__name__)
 
@@ -22,12 +22,23 @@ class LaFricheParser(BaseCrawler):
     La Friche is a major cultural center in Marseille hosting concerts,
     exhibitions, performances, and community events.
 
-    Note: This is a template parser. The actual CSS selectors and
-    extraction logic should be updated based on the current website
-    structure, which may change over time.
+    This parser uses the ConfigurableEventParser for selector-based
+    extraction and extends it with La Friche-specific logic.
     """
 
     source_name = "La Friche"
+
+    def __init__(self, *args, **kwargs):
+        """Initialize La Friche parser with configurable selectors."""
+        super().__init__(*args, **kwargs)
+
+        # Create configurable parser with our config
+        self._configurable_parser = ConfigurableEventParser(
+            config=self.config,
+            base_url=self.base_url,
+            source_id=self.source_id,
+            category_map=self.category_map,
+        )
 
     def parse_events(self, parser: HTMLParser) -> list[Event]:
         """
@@ -41,14 +52,12 @@ class LaFricheParser(BaseCrawler):
         """
         events = []
 
-        # NOTE: These selectors are examples and should be verified
-        # against the actual website structure
-        event_cards = parser.select(".event-card, .agenda-item, article.event")
+        # Try to use configurable parser first
+        event_cards = self._find_event_cards(parser)
 
         if not event_cards:
-            # Try alternative selectors
-            event_cards = parser.select("[class*='event'], [class*='agenda']")
-            logger.debug(f"Using fallback selectors, found {len(event_cards)} items")
+            logger.warning("No event cards found on La Friche page")
+            return events
 
         for card in event_cards:
             try:
@@ -59,6 +68,41 @@ class LaFricheParser(BaseCrawler):
                 logger.warning(f"Failed to parse event card: {e}")
 
         return events
+
+    def _find_event_cards(self, parser: HTMLParser):
+        """Find event cards using configured or fallback selectors."""
+        selectors = self._configurable_parser.selectors
+
+        # Try configured selectors
+        if selectors.event_list and selectors.event_item:
+            container = parser.select_one(selectors.event_list)
+            if container:
+                cards = container.select(selectors.event_item)
+                if cards:
+                    return cards
+
+        if selectors.event_item:
+            cards = parser.select(selectors.event_item)
+            if cards:
+                return cards
+
+        # Try common La Friche selectors
+        fallback_selectors = [
+            ".event-card",
+            ".agenda-item",
+            "article.event",
+            ".event",
+            "[class*='event']",
+            "[class*='agenda']",
+        ]
+
+        for selector in fallback_selectors:
+            cards = parser.select(selector)
+            if cards:
+                logger.debug(f"Using fallback selector: {selector}")
+                return cards
+
+        return []
 
     def _parse_event_card(self, card, parser: HTMLParser) -> Event | None:
         """
@@ -71,26 +115,31 @@ class LaFricheParser(BaseCrawler):
         Returns:
             Event object or None if parsing failed
         """
+        selectors = self._configurable_parser.selectors
+
         # Extract event name
-        name = parser.get_text(card, "h2, h3, .event-title, .title")
+        name = parser.get_text(card, selectors.name)
         if not name:
             logger.debug("Skipping card without name")
             return None
 
         # Extract event URL
-        event_url = parser.get_link(card, "a")
+        event_url = parser.get_link(card, selectors.link)
         if not event_url:
             logger.debug(f"Skipping event without URL: {name}")
             return None
 
         # Extract date and time
-        date_text = parser.get_text(card, ".date, .event-date, time")
-        time_text = parser.get_text(card, ".time, .event-time, .hour")
+        date_text = parser.get_text(card, selectors.date)
+        time_text = parser.get_text(card, selectors.time)
 
-        event_date = self._parse_date(date_text)
+        event_date = parser.parse_date(date_text)
         if not event_date:
-            logger.debug(f"Could not parse date for: {name} ({date_text})")
-            return None
+            # Try to parse date from the name or description
+            event_date = self._try_parse_date_from_text(name, parser)
+            if not event_date:
+                logger.debug(f"Could not parse date for: {name} ({date_text})")
+                return None
 
         event_time = parser.parse_time(time_text) or "20:00"
         hour, minute = map(int, event_time.split(":"))
@@ -99,18 +148,21 @@ class LaFricheParser(BaseCrawler):
         )
 
         # Extract description
-        description = parser.get_text(card, ".description, .excerpt, p")
-        description = parser.truncate(description, 160)
+        description = parser.get_text(card, selectors.description)
+        description = parser.truncate(description, 160) if description else ""
 
         # Extract image
-        image_url = parser.get_image(card, "img")
+        image_url = parser.get_image(card, selectors.image)
 
         # Extract category
-        category_text = parser.get_text(card, ".category, .tag, .type")
+        category_text = parser.get_text(card, selectors.category)
         category = self.map_category(category_text) if category_text else "communaute"
 
         # Generate source ID
         source_id = self._generate_source_id(event_url)
+
+        # Extract tags
+        tags = self._extract_tags(card, parser)
 
         # Create event
         return Event(
@@ -121,71 +173,22 @@ class LaFricheParser(BaseCrawler):
             image=image_url if image_url else None,
             categories=[category],
             locations=["la-friche"],
-            tags=self._extract_tags(card, parser),
+            tags=tags,
             source_id=source_id,
         )
 
-    def _parse_date(self, text: str) -> datetime | None:
+    def _try_parse_date_from_text(self, text: str, parser: HTMLParser) -> datetime | None:
         """
-        Parse French date formats.
+        Try to extract date from text content.
 
         Args:
-            text: Date text to parse
+            text: Text that might contain a date
+            parser: HTMLParser for parsing
 
         Returns:
-            datetime object or None
+            datetime or None
         """
-        if not text:
-            return None
-
-        # Clean text
-        text = text.strip().lower()
-
-        # French month names
-        months = {
-            "janvier": 1, "février": 2, "fevrier": 2, "mars": 3,
-            "avril": 4, "mai": 5, "juin": 6, "juillet": 7,
-            "août": 8, "aout": 8, "septembre": 9, "octobre": 10,
-            "novembre": 11, "décembre": 12, "decembre": 12,
-        }
-
-        # Try pattern: "26 janvier 2026" or "26 janvier"
-        pattern = r"(\d{1,2})\s+(\w+)(?:\s+(\d{4}))?"
-        match = re.search(pattern, text)
-
-        if match:
-            day = int(match.group(1))
-            month_name = match.group(2)
-            year = int(match.group(3)) if match.group(3) else datetime.now().year
-
-            month = months.get(month_name)
-            if month:
-                try:
-                    return datetime(year, month, day)
-                except ValueError:
-                    pass
-
-        # Try pattern: "26/01/2026" or "26/01"
-        pattern = r"(\d{1,2})/(\d{1,2})(?:/(\d{2,4}))?"
-        match = re.search(pattern, text)
-
-        if match:
-            day = int(match.group(1))
-            month = int(match.group(2))
-            year = match.group(3)
-            if year:
-                year = int(year)
-                if year < 100:
-                    year += 2000
-            else:
-                year = datetime.now().year
-
-            try:
-                return datetime(year, month, day)
-            except ValueError:
-                pass
-
-        return None
+        return parser.parse_date(text)
 
     def _generate_source_id(self, url: str) -> str:
         """
@@ -197,8 +200,6 @@ class LaFricheParser(BaseCrawler):
         Returns:
             Source ID string
         """
-        # Extract path or ID from URL
-        # Example: https://lafriche.org/event/concert-123 -> lafriche:concert-123
         from urllib.parse import urlparse
 
         parsed = urlparse(url)
@@ -222,9 +223,9 @@ class LaFricheParser(BaseCrawler):
             List of tag strings
         """
         tags = []
+        selectors = self._configurable_parser.selectors
 
-        # Look for tag elements
-        tag_elements = card.select(".tag, .label, .keyword")
+        tag_elements = card.select(selectors.tags)
         for elem in tag_elements:
             tag_text = elem.get_text().strip()
             if tag_text and len(tag_text) < 50:

--- a/crawler/tests/test_configurable_parser.py
+++ b/crawler/tests/test_configurable_parser.py
@@ -1,0 +1,397 @@
+"""Tests for configurable event parser."""
+
+from datetime import datetime
+
+import pytest
+
+from src.parsers.base import (
+    ConfigurableEventParser,
+    ParsedEvent,
+    SelectorConfig,
+)
+
+
+class TestSelectorConfig:
+    """Tests for SelectorConfig dataclass."""
+
+    def test_default_values(self):
+        config = SelectorConfig()
+        assert config.name == "h2, h3, .title, .event-title"
+        assert config.date == ".date, .event-date, time"
+        assert config.link == "a"
+
+    def test_from_dict(self):
+        data = {
+            "event_list": ".events-container",
+            "event_item": ".event-card",
+            "name": ".event-name",
+            "date": ".event-date",
+        }
+        config = SelectorConfig.from_dict(data)
+        assert config.event_list == ".events-container"
+        assert config.event_item == ".event-card"
+        assert config.name == ".event-name"
+        # Defaults still work for unspecified fields
+        assert config.link == "a"
+
+    def test_from_empty_dict(self):
+        config = SelectorConfig.from_dict({})
+        assert config.event_list == ""
+        assert config.event_item == ""
+        assert config.name == "h2, h3, .title, .event-title"
+
+
+class TestParsedEvent:
+    """Tests for ParsedEvent dataclass."""
+
+    def test_minimal_event(self):
+        event = ParsedEvent(
+            name="Test Event",
+            source_url="https://example.com/event/1",
+        )
+        assert event.name == "Test Event"
+        assert event.source_url == "https://example.com/event/1"
+        assert event.date is None
+        assert event.tags == []
+
+    def test_full_event(self):
+        event = ParsedEvent(
+            name="Concert Jazz",
+            source_url="https://example.com/events/jazz",
+            date=datetime(2026, 1, 26),
+            start_time="20:30",
+            location="La Friche",
+            description="Amazing jazz concert",
+            category="musique",
+            image_url="https://example.com/images/jazz.jpg",
+            tags=["jazz", "live", "free"],
+            raw_date="26 janvier 2026",
+            raw_time="20h30",
+        )
+        assert event.name == "Concert Jazz"
+        assert event.date.year == 2026
+        assert event.start_time == "20:30"
+        assert len(event.tags) == 3
+
+
+class TestConfigurableEventParser:
+    """Tests for ConfigurableEventParser class."""
+
+    @pytest.fixture
+    def sample_html(self):
+        """Sample HTML with event cards."""
+        return """
+        <html>
+        <body>
+            <div class="events-container">
+                <div class="event-card">
+                    <h2 class="event-title">Concert de Jazz</h2>
+                    <a href="/events/jazz-concert">Details</a>
+                    <img src="/images/jazz.jpg" alt="Jazz">
+                    <span class="event-date">26 janvier 2026</span>
+                    <span class="event-time">20h30</span>
+                    <span class="event-venue">La Friche</span>
+                    <p class="event-description">Un concert exceptionnel de jazz.</p>
+                    <span class="event-category">Musique</span>
+                    <span class="tag">jazz</span>
+                    <span class="tag">live</span>
+                </div>
+                <div class="event-card">
+                    <h2 class="event-title">Exposition Art Moderne</h2>
+                    <a href="/events/art-expo">Details</a>
+                    <img data-src="/images/art.jpg" alt="Art">
+                    <span class="event-date">27/01/2026</span>
+                    <span class="event-time">14:00</span>
+                    <span class="event-venue">Galerie Sud</span>
+                    <p class="event-description">Découvrez l'art moderne.</p>
+                    <span class="event-category">Art</span>
+                </div>
+            </div>
+        </body>
+        </html>
+        """
+
+    @pytest.fixture
+    def parser_config(self):
+        """Parser configuration with selectors."""
+        return {
+            "selectors": {
+                "event_list": ".events-container",
+                "event_item": ".event-card",
+                "name": ".event-title",
+                "date": ".event-date",
+                "time": ".event-time",
+                "location": ".event-venue",
+                "description": ".event-description",
+                "category": ".event-category",
+                "image": "img",
+                "link": "a",
+                "tags": ".tag",
+            }
+        }
+
+    @pytest.fixture
+    def parser(self, parser_config):
+        """Create parser with config."""
+        return ConfigurableEventParser(
+            config=parser_config,
+            base_url="https://example.com",
+            source_id="test",
+        )
+
+    def test_parse_events(self, parser, sample_html):
+        """Test parsing multiple events."""
+        events = parser.parse(sample_html)
+        assert len(events) == 2
+
+    def test_parse_event_name(self, parser, sample_html):
+        """Test event name extraction."""
+        events = parser.parse(sample_html)
+        assert events[0].name == "Concert de Jazz"
+        assert events[1].name == "Exposition Art Moderne"
+
+    def test_parse_event_url(self, parser, sample_html):
+        """Test event URL extraction and resolution."""
+        events = parser.parse(sample_html)
+        assert events[0].source_url == "https://example.com/events/jazz-concert"
+        assert events[1].source_url == "https://example.com/events/art-expo"
+
+    def test_parse_event_date(self, parser, sample_html):
+        """Test date parsing."""
+        events = parser.parse(sample_html)
+        assert events[0].date is not None
+        assert events[0].date.day == 26
+        assert events[0].date.month == 1
+        assert events[0].date.year == 2026
+
+        assert events[1].date is not None
+        assert events[1].date.day == 27
+
+    def test_parse_event_time(self, parser, sample_html):
+        """Test time extraction."""
+        events = parser.parse(sample_html)
+        assert events[0].start_time == "20:30"
+        assert events[1].start_time == "14:00"
+
+    def test_parse_event_location(self, parser, sample_html):
+        """Test location extraction."""
+        events = parser.parse(sample_html)
+        assert events[0].location == "La Friche"
+        assert events[1].location == "Galerie Sud"
+
+    def test_parse_event_description(self, parser, sample_html):
+        """Test description extraction."""
+        events = parser.parse(sample_html)
+        assert "jazz" in events[0].description.lower()
+        assert "art" in events[1].description.lower()
+
+    def test_parse_event_category(self, parser, sample_html):
+        """Test category extraction."""
+        events = parser.parse(sample_html)
+        assert events[0].category == "Musique"
+        assert events[1].category == "Art"
+
+    def test_parse_event_tags(self, parser, sample_html):
+        """Test tags extraction."""
+        events = parser.parse(sample_html)
+        assert "jazz" in events[0].tags
+        assert "live" in events[0].tags
+        assert len(events[1].tags) == 0  # No tags
+
+    def test_raw_date_preserved(self, parser, sample_html):
+        """Test that raw date string is preserved."""
+        events = parser.parse(sample_html)
+        assert events[0].raw_date == "26 janvier 2026"
+        assert events[1].raw_date == "27/01/2026"
+
+
+class TestConfigurableEventParserConversion:
+    """Tests for ParsedEvent to Event conversion."""
+
+    @pytest.fixture
+    def parser(self):
+        return ConfigurableEventParser(
+            config={"selectors": {}},
+            base_url="https://example.com",
+            source_id="test",
+            category_map={"Concert": "musique"},
+        )
+
+    def test_to_event_basic(self, parser):
+        """Test basic conversion."""
+        parsed = ParsedEvent(
+            name="Test Event",
+            source_url="https://example.com/event/1",
+            date=datetime(2026, 1, 26),
+            start_time="20:00",
+            category="Concert",
+        )
+        event = parser.to_event(parsed)
+
+        assert event.name == "Test Event"
+        assert event.event_url == "https://example.com/event/1"
+        assert event.start_datetime is not None
+        assert event.start_datetime.hour == 20
+        assert "musique" in event.categories
+
+    def test_to_event_default_time(self, parser):
+        """Test default time is applied."""
+        parsed = ParsedEvent(
+            name="Test Event",
+            source_url="https://example.com/event/1",
+            date=datetime(2026, 1, 26),
+        )
+        event = parser.to_event(parsed, default_time="19:00")
+
+        assert event.start_datetime.hour == 19
+        assert event.start_datetime.minute == 0
+
+    def test_to_event_source_id_generation(self, parser):
+        """Test source ID is generated."""
+        parsed = ParsedEvent(
+            name="Test Event",
+            source_url="https://example.com/events/my-event-123",
+            date=datetime(2026, 1, 26),
+        )
+        event = parser.to_event(parsed)
+
+        assert event.source_id == "test:my-event-123"
+
+    def test_category_mapping(self, parser):
+        """Test category mapping."""
+        # Explicit mapping
+        assert parser._map_category("Concert") == "musique"
+        # Default mapping
+        assert parser._map_category("Danse") == "danse"
+        assert parser._map_category("Exposition") == "art"
+        # Fallback
+        assert parser._map_category("Unknown") == "communaute"
+        assert parser._map_category(None) == "communaute"
+
+
+class TestConfigurableEventParserFallback:
+    """Tests for fallback selector behavior."""
+
+    @pytest.fixture
+    def html_with_fallback_selectors(self):
+        """HTML using common fallback selectors."""
+        return """
+        <html>
+        <body>
+            <article class="event">
+                <h3>Fallback Event</h3>
+                <a href="/fallback">Link</a>
+                <time>15 février 2026</time>
+            </article>
+        </body>
+        </html>
+        """
+
+    def test_fallback_selectors(self, html_with_fallback_selectors):
+        """Test fallback selectors are used when configured ones fail."""
+        parser = ConfigurableEventParser(
+            config={"selectors": {}},  # No configured selectors
+            base_url="https://example.com",
+            source_id="test",
+        )
+        events = parser.parse(html_with_fallback_selectors)
+        assert len(events) == 1
+        assert events[0].name == "Fallback Event"
+
+
+class TestConfigurableEventParserEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_empty_html(self):
+        """Test parsing empty HTML."""
+        parser = ConfigurableEventParser(
+            config={"selectors": {}},
+            base_url="https://example.com",
+            source_id="test",
+        )
+        events = parser.parse("")
+        assert len(events) == 0
+
+    def test_html_without_events(self):
+        """Test parsing HTML without event elements."""
+        html = "<html><body><p>No events here</p></body></html>"
+        parser = ConfigurableEventParser(
+            config={"selectors": {}},
+            base_url="https://example.com",
+            source_id="test",
+        )
+        events = parser.parse(html)
+        assert len(events) == 0
+
+    def test_event_without_name_skipped(self):
+        """Test events without names are skipped."""
+        html = """
+        <div class="event-card">
+            <a href="/event/1">Link</a>
+        </div>
+        """
+        parser = ConfigurableEventParser(
+            config={"selectors": {"event_item": ".event-card"}},
+            base_url="https://example.com",
+            source_id="test",
+        )
+        events = parser.parse(html)
+        assert len(events) == 0
+
+    def test_event_without_url_skipped(self):
+        """Test events without URLs are skipped."""
+        html = """
+        <div class="event-card">
+            <h2>Event Without URL</h2>
+        </div>
+        """
+        parser = ConfigurableEventParser(
+            config={"selectors": {"event_item": ".event-card"}},
+            base_url="https://example.com",
+            source_id="test",
+        )
+        events = parser.parse(html)
+        assert len(events) == 0
+
+    def test_malformed_html(self):
+        """Test parsing malformed HTML doesn't crash."""
+        html = "<div class='event-card'><h2>Broken Event</h2><a href='/test'>Link"
+        parser = ConfigurableEventParser(
+            config={"selectors": {"event_item": ".event-card"}},
+            base_url="https://example.com",
+            source_id="test",
+        )
+        # Should not raise exception
+        events = parser.parse(html)
+        # BeautifulSoup should handle malformed HTML gracefully
+        assert len(events) == 1
+        assert events[0].name == "Broken Event"
+
+
+class TestParseAndConvert:
+    """Tests for the parse_and_convert convenience method."""
+
+    @pytest.fixture
+    def sample_html(self):
+        return """
+        <div class="event-card">
+            <h2>Quick Event</h2>
+            <a href="/quick">Link</a>
+            <span class="date">28 janvier 2026</span>
+        </div>
+        """
+
+    def test_parse_and_convert(self, sample_html):
+        """Test combined parse and convert."""
+        parser = ConfigurableEventParser(
+            config={"selectors": {"event_item": ".event-card", "date": ".date"}},
+            base_url="https://example.com",
+            source_id="test",
+        )
+        events = parser.parse_and_convert(sample_html)
+
+        assert len(events) == 1
+        assert events[0].name == "Quick Event"
+        assert events[0].event_url == "https://example.com/quick"
+        assert events[0].start_datetime is not None
+        assert events[0].source_id == "test:quick"


### PR DESCRIPTION
## Summary

Implements issue #19 by adding a configurable HTML parser system that extracts event data using CSS selectors defined in YAML configuration.

### New Components

- **ParsedEvent** (`src/parsers/base.py:22-44`): Intermediate dataclass for parsed event data, preserving raw strings for debugging
- **SelectorConfig** (`src/parsers/base.py:47-76`): Configuration dataclass for CSS selectors, loadable from YAML
- **ConfigurableEventParser** (`src/parsers/base.py:79-310`): Flexible parser using configurable selectors with fallback support

### Key Features

- CSS selector-based extraction configurable in `sources.yaml`
- French date parsing ("26 janvier 2026", "26/01/2026")
- Time parsing ("20h30", "14:00", "19h")
- Automatic URL resolution (relative to absolute)
- Category mapping from source to standard taxonomy
- Graceful handling of malformed HTML and missing fields
- Fallback selectors for common event HTML patterns

### Changes

- `src/parsers/base.py`: New configurable parser module
- `src/parsers/__init__.py`: Export new classes and add "generic" parser
- `src/parsers/lafriche.py`: Updated to use ConfigurableEventParser
- `config/sources.yaml`: Added detailed selector configuration for La Friche
- `tests/test_configurable_parser.py`: 26 new tests

## Test plan

- [x] Run `pytest tests/test_configurable_parser.py` - 26 passed
- [x] Run `pytest tests/` - 157 passed, 2 skipped
- [x] Run `ruff check` - no linting issues

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)