### PR TITLE
Add comprehensive CLI with subcommands for crawler management

### DIFF
--- a/crawler/README.md
+++ b/crawler/README.md
@@ -33,39 +33,87 @@ The crawler fetches events from configured sources, extracts event data, downloa
 
 ## Usage
 
-### Basic Usage
+### Quick Start
 
-Run all enabled sources:
 ```bash
+# Show help and available commands
 python crawl.py
+
+# Run full crawl
+python crawl.py run
+
+# Preview what would be created (dry run)
+python crawl.py run --dry-run
+
+# List configured sources
+python crawl.py list-sources
+
+# Check configuration
+python crawl.py validate
+
+# Show last crawl results
+python crawl.py status
+
+# Clean expired events
+python crawl.py clean
 ```
 
-### Command Line Options
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `run` | Execute crawler for all/specific sources |
+| `list-sources` | Show configured event sources |
+| `validate` | Check configuration for errors |
+| `status` | Show last crawl results |
+| `clean` | Mark old events as expired |
+
+### Global Options
 
 | Option | Short | Description |
 |--------|-------|-------------|
 | `--config PATH` | `-c` | Path to configuration file (default: config.yaml) |
-| `--source NAME` | `-s` | Run only the specified source by ID or parser name |
-| `--dry-run` | `-n` | Preview actions without writing files |
 | `--log-level LEVEL` | `-l` | Override log level (DEBUG, INFO, WARNING, ERROR, CRITICAL) |
 | `--log-file PATH` | | Override log file path from config |
-| `--list-sources` | | List all configured sources and exit |
+| `--version` | | Show version and exit |
+| `--help` | | Show help message |
+
+### Run Command Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--source NAME` | `-s` | Run only the specified source by ID |
+| `--dry-run` | `-n` | Preview actions without writing files |
 | `--skip-selection` | | Skip selection criteria filtering (include all events) |
+
+### Clean Command Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--before DATE` | `-b` | Clean events before this date (default: today) |
+| `--dry-run` | `-n` | Preview what would be cleaned |
+| `--delete` | | Delete files instead of marking as expired |
 
 ### Examples
 
 ```bash
-# Run only La Friche parser
-python crawl.py --source lafriche
+# Run specific source
+python crawl.py run --source lafriche
 
-# Preview what would be created
-python crawl.py --dry-run
+# Preview crawl results
+python crawl.py run --dry-run
 
 # Verbose output for debugging
-python crawl.py --log-level DEBUG
+python crawl.py run --log-level DEBUG
 
-# Use custom config file
-python crawl.py --config /path/to/config.yaml
+# Clean events older than a specific date
+python crawl.py clean --before 2026-01-01
+
+# Preview what would be cleaned
+python crawl.py clean --dry-run
+
+# Delete old event files instead of marking expired
+python crawl.py clean --delete
 ```
 
 ## Logging

--- a/crawler/config/sources.schema.json
+++ b/crawler/config/sources.schema.json
@@ -139,6 +139,42 @@
         "event_category": {
           "type": "string",
           "description": "CSS selector for event category"
+        },
+        "name": {
+          "type": "string",
+          "description": "CSS selector for event name/title (alias for event_title)"
+        },
+        "date": {
+          "type": "string",
+          "description": "CSS selector for event date (alias for event_date)"
+        },
+        "time": {
+          "type": "string",
+          "description": "CSS selector for event time (alias for event_time)"
+        },
+        "link": {
+          "type": "string",
+          "description": "CSS selector for event link (alias for event_link)"
+        },
+        "image": {
+          "type": "string",
+          "description": "CSS selector for event image (alias for event_image)"
+        },
+        "description": {
+          "type": "string",
+          "description": "CSS selector for event description (alias for event_description)"
+        },
+        "category": {
+          "type": "string",
+          "description": "CSS selector for event category (alias for event_category)"
+        },
+        "location": {
+          "type": "string",
+          "description": "CSS selector for event location/venue"
+        },
+        "tags": {
+          "type": "string",
+          "description": "CSS selector for event tags"
         }
       },
       "additionalProperties": false

--- a/crawler/crawl.py
+++ b/crawler/crawl.py
@@ -3,28 +3,43 @@
 Massalia Events Crawler
 =======================
 
-Main entry point for crawling Marseille cultural event websites.
+Command-line interface for crawling Marseille cultural event websites.
 
 Usage:
-    python crawl.py                    # Run all enabled sources
-    python crawl.py --source lafriche  # Run specific source (by ID)
-    python crawl.py --dry-run          # Preview without writing files
-    python crawl.py --log-level DEBUG  # Verbose output
-    python crawl.py --skip-selection   # Skip selection criteria filtering
+    python crawl.py run                       # Run all enabled sources
+    python crawl.py run --source lafriche     # Run specific source
+    python crawl.py run --dry-run             # Preview without writing files
+    python crawl.py list-sources              # List configured sources
+    python crawl.py validate                  # Check configuration
+    python crawl.py status                    # Show last crawl results
+    python crawl.py clean                     # Remove expired events
 """
 
+import json
+import signal
 import sys
+from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import click
 import yaml
 
-from src.config import ConfigurationError, load_sources_config
+from src.config import ConfigurationError, load_sources_config, validate_sources_config
 from src.generators import MarkdownGenerator
 from src.logger import get_logger, setup_logging
 from src.parsers import get_parser
 from src.selection import load_selection_criteria
 from src.utils import HTTPClient, ImageDownloader
+
+# Paris timezone for Marseille events
+PARIS_TZ = ZoneInfo("Europe/Paris")
+
+# Status file for tracking crawl results
+STATUS_FILE = ".crawl_status.json"
+
+# Global flag for interrupt handling
+_interrupted = False
 
 
 def load_config(config_path: Path) -> dict:
@@ -36,27 +51,75 @@ def load_config(config_path: Path) -> dict:
         return yaml.safe_load(f)
 
 
-@click.command()
+def setup_logging_from_config(
+    config: dict,
+    config_dir: Path,
+    log_level_override: str | None = None,
+    log_file_override: Path | None = None,
+) -> None:
+    """Configure logging based on config file and CLI overrides."""
+    # Get logging configuration (support both old flat format and new nested format)
+    logging_cfg = config.get("logging", {})
+    if not logging_cfg:
+        # Backwards compatibility with old flat config format
+        logging_cfg = {
+            "log_level": config.get("log_level", "INFO"),
+            "log_file": config.get("log_file"),
+        }
+
+    # CLI flags override config file settings
+    effective_log_level = log_level_override or logging_cfg.get("log_level", "INFO")
+    effective_log_file = log_file_override or logging_cfg.get("log_file")
+    log_dir = config_dir if effective_log_file else None
+
+    setup_logging(
+        level=effective_log_level,
+        log_file=str(effective_log_file) if effective_log_file else None,
+        log_dir=log_dir,
+        log_format=logging_cfg.get("log_format", "text"),
+        max_bytes=logging_cfg.get("max_file_size", 10 * 1024 * 1024),
+        backup_count=logging_cfg.get("backup_count", 5),
+    )
+
+
+def save_status(config_dir: Path, status: dict) -> None:
+    """Save crawl status to file."""
+    status_path = config_dir / STATUS_FILE
+    status["timestamp"] = datetime.now(PARIS_TZ).isoformat()
+    with open(status_path, "w", encoding="utf-8") as f:
+        json.dump(status, f, indent=2)
+
+
+def load_status(config_dir: Path) -> dict | None:
+    """Load last crawl status from file."""
+    status_path = config_dir / STATUS_FILE
+    if not status_path.exists():
+        return None
+    with open(status_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def signal_handler(signum, frame):
+    """Handle interrupt signals gracefully."""
+    global _interrupted
+    _interrupted = True
+    click.echo(
+        click.style("\n\nInterrupt received, finishing current task...", fg="yellow")
+    )
+
+
+# Set up signal handlers
+signal.signal(signal.SIGINT, signal_handler)
+signal.signal(signal.SIGTERM, signal_handler)
+
+
+@click.group(invoke_without_command=True)
 @click.option(
     "--config",
     "-c",
     type=click.Path(exists=True, path_type=Path),
     default=Path(__file__).parent / "config.yaml",
     help="Path to configuration file",
-)
-@click.option(
-    "--source",
-    "-s",
-    type=str,
-    default=None,
-    help="Run only specified source (by source ID)",
-)
-@click.option(
-    "--dry-run",
-    "-n",
-    is_flag=True,
-    default=False,
-    help="Preview actions without writing files",
 )
 @click.option(
     "--log-level",
@@ -73,11 +136,47 @@ def load_config(config_path: Path) -> dict:
     default=None,
     help="Override log file path from config",
 )
+@click.version_option(version="1.0.0", prog_name="massalia-crawler")
+@click.pass_context
+def cli(ctx, config: Path, log_level: str | None, log_file: Path | None):
+    """
+    Massalia Events Crawler - Aggregate cultural events from Marseille.
+
+    This crawler fetches events from configured sources, extracts event data,
+    downloads images, and generates Hugo-compatible markdown files.
+    """
+    ctx.ensure_object(dict)
+    ctx.obj["config_path"] = config
+    ctx.obj["config_dir"] = config.parent
+    ctx.obj["log_level"] = log_level
+    ctx.obj["log_file"] = log_file
+
+    # Load config
+    try:
+        ctx.obj["config"] = load_config(config)
+    except FileNotFoundError as e:
+        click.echo(click.style(f"Error: {e}", fg="red"), err=True)
+        sys.exit(1)
+
+    # If no subcommand is provided, show help
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@cli.command()
 @click.option(
-    "--list-sources",
+    "--source",
+    "-s",
+    type=str,
+    default=None,
+    help="Run only specified source (by source ID)",
+)
+@click.option(
+    "--dry-run",
+    "-n",
     is_flag=True,
     default=False,
-    help="List all configured sources and exit",
+    help="Preview actions without writing files",
 )
 @click.option(
     "--skip-selection",
@@ -85,53 +184,27 @@ def load_config(config_path: Path) -> dict:
     default=False,
     help="Skip selection criteria filtering (include all events)",
 )
-def main(
-    config: Path,
-    source: str | None,
-    dry_run: bool,
-    log_level: str | None,
-    log_file: Path | None,
-    list_sources: bool,
-    skip_selection: bool,
-):
+@click.pass_context
+def run(ctx, source: str | None, dry_run: bool, skip_selection: bool):
     """
-    Crawl Marseille event websites and generate Hugo content.
+    Run the crawler to fetch and process events.
 
-    This crawler fetches events from configured sources, extracts event data,
-    downloads images, and generates Hugo-compatible markdown files.
-
-    Events are filtered using selection criteria defined in
-    config/selection-criteria.yaml before being added to the calendar.
+    By default, crawls all enabled sources. Use --source to crawl a specific source.
+    Use --dry-run to preview what would be created without writing files.
     """
-    # Load main configuration
-    cfg = load_config(config)
+    global _interrupted
 
-    # Get logging configuration (support both old flat format and new nested format)
-    logging_cfg = cfg.get("logging", {})
-    if not logging_cfg:
-        # Backwards compatibility with old flat config format
-        logging_cfg = {
-            "log_level": cfg.get("log_level", "INFO"),
-            "log_file": cfg.get("log_file"),
-        }
+    cfg = ctx.obj["config"]
+    config_dir = ctx.obj["config_dir"]
+    log_level = ctx.obj["log_level"]
+    log_file = ctx.obj["log_file"]
 
-    # CLI flags override config file settings
-    effective_log_level = log_level or logging_cfg.get("log_level", "INFO")
-    effective_log_file = log_file or logging_cfg.get("log_file")
-
-    # Get log directory relative to config file location
-    config_dir = config.parent
-    log_dir = config_dir if effective_log_file else None
-
-    setup_logging(
-        level=effective_log_level,
-        log_file=str(effective_log_file) if effective_log_file else None,
-        log_dir=log_dir,
-        log_format=logging_cfg.get("log_format", "text"),
-        max_bytes=logging_cfg.get("max_file_size", 10 * 1024 * 1024),
-        backup_count=logging_cfg.get("backup_count", 5),
-    )
+    # Setup logging
+    setup_logging_from_config(cfg, config_dir, log_level, log_file)
     logger = get_logger(__name__)
+
+    # Track effective log level for stack traces
+    effective_log_level = log_level or cfg.get("logging", {}).get("log_level", "INFO")
 
     # Load sources configuration
     sources_file = config_dir / cfg.get("sources_file", "config/sources.yaml")
@@ -152,23 +225,10 @@ def main(
     else:
         selection_criteria = load_selection_criteria(selection_file)
 
-    # Handle --list-sources
-    if list_sources:
-        click.echo("\nConfigured sources:")
-        click.echo("-" * 60)
-        for src in sources_config.sources:
-            status = "enabled" if src.enabled else "disabled"
-            click.echo(f"  {src.id:20} {src.name:30} [{status}]")
-        click.echo(
-            f"\nTotal: {len(sources_config.sources)} sources "
-            f"({len(sources_config.get_enabled_sources())} enabled)"
-        )
-        return
-
     logger.info("Massalia Events Crawler starting...")
 
     if dry_run:
-        logger.info("DRY RUN MODE - No files will be written")
+        click.echo(click.style("DRY RUN MODE - No files will be written", fg="yellow"))
 
     # Resolve output paths relative to config file location
     output_dir = config_dir / cfg.get("output_dir", "../content/events")
@@ -221,16 +281,29 @@ def main(
         logger.warning("No sources to process")
         return
 
-    # Process each source
+    # Process each source with progress display
     total_events = 0
     total_accepted = 0
     total_rejected = 0
+    total_errors = 0
+    sources_processed = 0
+    sources_total = len(sources_list)
 
-    for src in sources_list:
+    for i, src in enumerate(sources_list, 1):
+        if _interrupted:
+            click.echo(
+                click.style(
+                    f"\nInterrupted after {sources_processed} sources", fg="yellow"
+                )
+            )
+            break
+
         if not src.enabled:
             logger.debug(f"Skipping disabled source: {src.name}")
             continue
 
+        # Progress display
+        click.echo(f"\n[{i}/{sources_total}] Processing: {src.name} ({src.id})")
         logger.info(f"Processing source: {src.name} ({src.id})")
 
         # Build source config dict for parser (backwards compatibility)
@@ -263,35 +336,415 @@ def main(
             events = parser.crawl()
             event_count = len(events)
             total_events += event_count
+            sources_processed += 1
 
             # Track selection stats if available
             if hasattr(parser, "selection_stats"):
                 stats = parser.selection_stats
-                total_accepted += stats.get("accepted", event_count)
-                total_rejected += stats.get("rejected", 0)
-                logger.info(
-                    f"  {src.name}: {stats.get('accepted', event_count)} accepted, "
-                    f"{stats.get('rejected', 0)} rejected"
-                )
+                accepted = stats.get("accepted", event_count)
+                rejected = stats.get("rejected", 0)
+                total_accepted += accepted
+                total_rejected += rejected
+                click.echo(f"    -> {accepted} accepted, {rejected} rejected")
             else:
                 total_accepted += event_count
-                logger.info(f"  Found {event_count} events from {src.name}")
+                click.echo(f"    -> {event_count} events found")
 
         except ValueError as e:
             logger.warning(f"Parser not available for {src.name}: {e}")
+            total_errors += 1
         except Exception as e:
             logger.error(f"Error processing {src.name}: {e}")
+            total_errors += 1
             if effective_log_level == "DEBUG":
                 logger.exception("Full traceback:")
 
     # Summary
-    logger.info(f"Crawl complete. Total events processed: {total_accepted}")
-    if total_rejected > 0:
-        logger.info(f"Events rejected by selection criteria: {total_rejected}")
+    click.echo("\n" + "=" * 50)
+    click.echo(click.style("CRAWL SUMMARY", bold=True))
+    click.echo("=" * 50)
+    click.echo(f"  Sources processed:  {sources_processed}/{sources_total}")
+    click.echo(f"  Events accepted:    {total_accepted}")
+    click.echo(f"  Events rejected:    {total_rejected}")
+    click.echo(f"  Errors:             {total_errors}")
+    click.echo("=" * 50)
 
     if dry_run:
-        logger.info("DRY RUN - No files were written")
+        click.echo(click.style("\nDRY RUN - No files were written", fg="yellow"))
+
+    # Save status
+    save_status(
+        config_dir,
+        {
+            "sources_processed": sources_processed,
+            "sources_total": sources_total,
+            "events_accepted": total_accepted,
+            "events_rejected": total_rejected,
+            "errors": total_errors,
+            "dry_run": dry_run,
+            "interrupted": _interrupted,
+        },
+    )
+
+    # Exit code
+    if _interrupted:
+        sys.exit(130)  # Standard exit code for SIGINT
+    elif total_errors > 0:
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+@cli.command("list-sources")
+@click.pass_context
+def list_sources(ctx):
+    """
+    List all configured event sources.
+
+    Shows source ID, name, and enabled status for each configured source.
+    """
+    cfg = ctx.obj["config"]
+    config_dir = ctx.obj["config_dir"]
+
+    # Load sources configuration
+    sources_file = config_dir / cfg.get("sources_file", "config/sources.yaml")
+
+    try:
+        sources_config = load_sources_config(sources_file)
+    except ConfigurationError as e:
+        click.echo(click.style(f"Configuration error: {e}", fg="red"), err=True)
+        sys.exit(1)
+
+    click.echo("\nConfigured sources:")
+    click.echo("-" * 70)
+    click.echo(f"{'ID':<20} {'NAME':<30} {'STATUS':<10} {'PARSER':<15}")
+    click.echo("-" * 70)
+
+    for src in sources_config.sources:
+        status = (
+            click.style("enabled", fg="green")
+            if src.enabled
+            else click.style("disabled", fg="red")
+        )
+        click.echo(f"{src.id:<20} {src.name:<30} {status:<19} {src.parser:<15}")
+
+    click.echo("-" * 70)
+    enabled_count = len(sources_config.get_enabled_sources())
+    total_count = len(sources_config.sources)
+    click.echo(f"Total: {total_count} sources ({enabled_count} enabled)")
+
+
+@cli.command()
+@click.pass_context
+def validate(ctx):
+    """
+    Validate configuration files.
+
+    Checks config.yaml, sources.yaml, and selection-criteria.yaml for errors.
+    Reports any validation issues found.
+    """
+    cfg = ctx.obj["config"]
+    config_path = ctx.obj["config_path"]
+    config_dir = ctx.obj["config_dir"]
+
+    errors = []
+    warnings = []
+
+    click.echo("\nValidating configuration files...\n")
+
+    # 1. Validate main config.yaml
+    click.echo(f"  Checking {config_path.name}...")
+    required_keys = ["sources_file"]
+    for key in required_keys:
+        if key not in cfg:
+            errors.append(f"Missing required key in config.yaml: {key}")
+
+    # Check optional but recommended keys
+    recommended_keys = ["output_dir", "image_dir", "http", "logging"]
+    for key in recommended_keys:
+        if key not in cfg:
+            warnings.append(f"Missing recommended key in config.yaml: {key}")
+
+    if not errors:
+        click.echo(click.style("    ✓ config.yaml is valid", fg="green"))
+
+    # 2. Validate sources.yaml
+    sources_file = config_dir / cfg.get("sources_file", "config/sources.yaml")
+    click.echo(f"  Checking {sources_file.name}...")
+
+    if not sources_file.exists():
+        errors.append(f"Sources file not found: {sources_file}")
+    else:
+        try:
+            with open(sources_file, encoding="utf-8") as f:
+                sources_cfg = yaml.safe_load(f)
+
+            # Validate against schema
+            try:
+                validate_sources_config(sources_cfg, sources_file.parent)
+                click.echo(click.style("    ✓ sources.yaml is valid", fg="green"))
+            except ConfigurationError as e:
+                errors.append(f"Sources validation error: {e}")
+
+            # Check for valid parser names
+            from src.parsers import PARSERS
+
+            for source in sources_cfg.get("sources", []):
+                parser_name = source.get("parser")
+                if parser_name and parser_name not in PARSERS:
+                    warnings.append(
+                        f"Unknown parser '{parser_name}' for source '{source.get('id')}'"
+                    )
+
+        except yaml.YAMLError as e:
+            errors.append(f"Invalid YAML in sources.yaml: {e}")
+
+    # 3. Validate selection-criteria.yaml
+    selection_file = config_dir / cfg.get(
+        "selection_file", "config/selection-criteria.yaml"
+    )
+    click.echo(f"  Checking {selection_file.name}...")
+
+    if not selection_file.exists():
+        warnings.append(f"Selection criteria file not found: {selection_file}")
+        click.echo(click.style("    ! File not found (using defaults)", fg="yellow"))
+    else:
+        try:
+            with open(selection_file, encoding="utf-8") as f:
+                selection_cfg = yaml.safe_load(f)
+
+            if selection_cfg:
+                click.echo(
+                    click.style("    ✓ selection-criteria.yaml is valid", fg="green")
+                )
+            else:
+                warnings.append("Selection criteria file is empty")
+                click.echo(
+                    click.style("    ! File is empty (using defaults)", fg="yellow")
+                )
+
+        except yaml.YAMLError as e:
+            errors.append(f"Invalid YAML in selection-criteria.yaml: {e}")
+
+    # 4. Check output directories
+    click.echo("  Checking output directories...")
+    output_dir = config_dir / cfg.get("output_dir", "../content/events")
+    image_dir = config_dir / cfg.get("image_dir", "../static/images/events")
+
+    for dir_path, name in [(output_dir, "output_dir"), (image_dir, "image_dir")]:
+        if dir_path.exists():
+            click.echo(click.style(f"    ✓ {name} exists: {dir_path}", fg="green"))
+        else:
+            warnings.append(f"{name} does not exist: {dir_path}")
+            click.echo(click.style(f"    ! {name} not found: {dir_path}", fg="yellow"))
+
+    # Report results
+    click.echo("\n" + "=" * 50)
+    if errors:
+        click.echo(click.style("VALIDATION FAILED", fg="red", bold=True))
+        click.echo("=" * 50)
+        click.echo("\nErrors:")
+        for error in errors:
+            click.echo(click.style(f"  ✗ {error}", fg="red"))
+    else:
+        click.echo(click.style("VALIDATION PASSED", fg="green", bold=True))
+        click.echo("=" * 50)
+
+    if warnings:
+        click.echo("\nWarnings:")
+        for warning in warnings:
+            click.echo(click.style(f"  ! {warning}", fg="yellow"))
+
+    click.echo()
+
+    sys.exit(1 if errors else 0)
+
+
+@cli.command()
+@click.pass_context
+def status(ctx):
+    """
+    Show last crawl results.
+
+    Displays summary statistics from the most recent crawl run.
+    """
+    config_dir = ctx.obj["config_dir"]
+
+    status_data = load_status(config_dir)
+
+    if not status_data:
+        click.echo("No previous crawl status found.")
+        click.echo("Run 'python crawl.py run' to perform a crawl.")
+        return
+
+    click.echo("\n" + "=" * 50)
+    click.echo(click.style("LAST CRAWL STATUS", bold=True))
+    click.echo("=" * 50)
+
+    timestamp = status_data.get("timestamp", "Unknown")
+    click.echo(f"  Timestamp:          {timestamp}")
+    click.echo(
+        f"  Sources processed:  {status_data.get('sources_processed', 0)}/{status_data.get('sources_total', 0)}"
+    )
+    click.echo(f"  Events accepted:    {status_data.get('events_accepted', 0)}")
+    click.echo(f"  Events rejected:    {status_data.get('events_rejected', 0)}")
+    click.echo(f"  Errors:             {status_data.get('errors', 0)}")
+
+    if status_data.get("dry_run"):
+        click.echo(click.style("  Mode:               DRY RUN", fg="yellow"))
+
+    if status_data.get("interrupted"):
+        click.echo(click.style("  Status:             INTERRUPTED", fg="yellow"))
+    elif status_data.get("errors", 0) > 0:
+        click.echo(click.style("  Status:             COMPLETED WITH ERRORS", fg="red"))
+    else:
+        click.echo(click.style("  Status:             SUCCESS", fg="green"))
+
+    click.echo("=" * 50)
+
+
+@cli.command()
+@click.option(
+    "--before",
+    "-b",
+    type=click.DateTime(formats=["%Y-%m-%d"]),
+    default=None,
+    help="Clean events before this date (default: today)",
+)
+@click.option(
+    "--dry-run",
+    "-n",
+    is_flag=True,
+    default=False,
+    help="Preview what would be cleaned without making changes",
+)
+@click.option(
+    "--delete",
+    is_flag=True,
+    default=False,
+    help="Delete files instead of marking as expired",
+)
+@click.pass_context
+def clean(ctx, before: datetime | None, dry_run: bool, delete: bool):
+    """
+    Clean up expired events.
+
+    Marks events with dates before the specified date as expired,
+    or optionally deletes them. By default, cleans events before today.
+    """
+    cfg = ctx.obj["config"]
+    config_dir = ctx.obj["config_dir"]
+
+    # Setup logging
+    setup_logging_from_config(
+        cfg, config_dir, ctx.obj["log_level"], ctx.obj["log_file"]
+    )
+    logger = get_logger(__name__)
+
+    # Default to today
+    if before is None:
+        before = datetime.now(PARIS_TZ)
+    else:
+        before = before.replace(tzinfo=PARIS_TZ)
+
+    # Get output directory
+    output_dir = config_dir / cfg.get("output_dir", "../content/events")
+
+    if not output_dir.exists():
+        click.echo(
+            click.style(f"Output directory not found: {output_dir}", fg="red"), err=True
+        )
+        sys.exit(1)
+
+    click.echo(f"\nCleaning events before: {before.strftime('%Y-%m-%d')}")
+    if dry_run:
+        click.echo(click.style("DRY RUN MODE - No changes will be made", fg="yellow"))
+
+    # Find all markdown files
+    md_files = list(output_dir.rglob("*.md"))
+    cleaned_count = 0
+    error_count = 0
+
+    for md_file in md_files:
+        try:
+            content = md_file.read_text(encoding="utf-8")
+
+            # Parse front matter
+            if not content.startswith("---"):
+                continue
+
+            end_index = content.index("---", 3)
+            front_matter = yaml.safe_load(content[3:end_index])
+            body = content[end_index + 3 :]
+
+            # Skip files with invalid front matter
+            if not front_matter or not isinstance(front_matter, dict):
+                continue
+
+            # Check if already expired
+            if front_matter.get("expired", False):
+                continue
+
+            # Get event date from front matter
+            date_str = front_matter.get("date")
+            if not date_str:
+                continue
+
+            # Parse date - handle both string and datetime
+            if isinstance(date_str, datetime):
+                event_date = date_str
+            else:
+                event_date = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+
+            # Check if event is before cutoff
+            if event_date.date() >= before.date():
+                continue
+
+            # Event should be cleaned
+            event_name = front_matter.get("name", md_file.stem)
+
+            if delete:
+                if dry_run:
+                    click.echo(f"  [DRY RUN] Would delete: {md_file.name}")
+                else:
+                    md_file.unlink()
+                    click.echo(f"  Deleted: {md_file.name}")
+                    logger.info(f"Deleted expired event: {event_name}")
+            else:
+                if dry_run:
+                    click.echo(f"  [DRY RUN] Would mark expired: {md_file.name}")
+                else:
+                    # Mark as expired
+                    front_matter["expired"] = True
+                    new_content = (
+                        "---\n"
+                        + yaml.dump(
+                            front_matter, allow_unicode=True, default_flow_style=False
+                        )
+                        + "---"
+                        + body
+                    )
+                    md_file.write_text(new_content, encoding="utf-8")
+                    click.echo(f"  Marked expired: {md_file.name}")
+                    logger.info(f"Marked event as expired: {event_name}")
+
+            cleaned_count += 1
+
+        except Exception as e:
+            logger.error(f"Error processing {md_file}: {e}")
+            error_count += 1
+
+    # Summary
+    click.echo("\n" + "=" * 50)
+    action = "deleted" if delete else "marked expired"
+    if dry_run:
+        click.echo(f"Would have {action}: {cleaned_count} events")
+    else:
+        click.echo(f"Events {action}: {cleaned_count}")
+    if error_count > 0:
+        click.echo(click.style(f"Errors: {error_count}", fg="red"))
+    click.echo("=" * 50)
 
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/crawler/tests/test_cli.py
+++ b/crawler/tests/test_cli.py
@@ -1,0 +1,429 @@
+"""Tests for the command-line interface."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from crawl import (
+    cli,
+    load_config,
+    load_status,
+    save_status,
+    setup_logging_from_config,
+)
+
+
+@pytest.fixture
+def runner():
+    """Create a CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def temp_config_dir():
+    """Create a temporary directory with config files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+
+        # Create config.yaml
+        config = {
+            "sources_file": "config/sources.yaml",
+            "output_dir": "content/events",
+            "image_dir": "static/images/events",
+            "logging": {
+                "log_level": "INFO",
+            },
+            "http": {
+                "timeout": 30,
+            },
+        }
+        config_path = tmpdir / "config.yaml"
+        with open(config_path, "w") as f:
+            yaml.dump(config, f)
+
+        # Create config directory
+        config_dir = tmpdir / "config"
+        config_dir.mkdir()
+
+        # Create sources.yaml
+        sources = {
+            "sources": [
+                {
+                    "name": "Test Source",
+                    "id": "test-source",
+                    "url": "https://example.com/events",
+                    "parser": "generic",
+                    "enabled": True,
+                }
+            ]
+        }
+        with open(config_dir / "sources.yaml", "w") as f:
+            yaml.dump(sources, f)
+
+        # Create selection-criteria.yaml
+        selection = {
+            "geography": {"required_areas": ["Marseille"]},
+        }
+        with open(config_dir / "selection-criteria.yaml", "w") as f:
+            yaml.dump(selection, f)
+
+        # Create output directory
+        (tmpdir / "content" / "events").mkdir(parents=True)
+
+        yield tmpdir
+
+
+class TestLoadConfig:
+    """Tests for load_config function."""
+
+    def test_load_valid_config(self, temp_config_dir):
+        """Test loading a valid config file."""
+        config_path = temp_config_dir / "config.yaml"
+        config = load_config(config_path)
+        assert config["sources_file"] == "config/sources.yaml"
+        assert config["output_dir"] == "content/events"
+
+    def test_load_nonexistent_config(self):
+        """Test loading a nonexistent config file."""
+        with pytest.raises(FileNotFoundError):
+            load_config(Path("/nonexistent/config.yaml"))
+
+
+class TestStatusFunctions:
+    """Tests for status save/load functions."""
+
+    def test_save_and_load_status(self, temp_config_dir):
+        """Test saving and loading status."""
+        status = {
+            "sources_processed": 3,
+            "sources_total": 5,
+            "events_accepted": 42,
+            "events_rejected": 10,
+            "errors": 1,
+            "dry_run": False,
+            "interrupted": False,
+        }
+        save_status(temp_config_dir, status)
+
+        loaded = load_status(temp_config_dir)
+        assert loaded["sources_processed"] == 3
+        assert loaded["events_accepted"] == 42
+        assert "timestamp" in loaded
+
+    def test_load_missing_status(self, temp_config_dir):
+        """Test loading status when file doesn't exist."""
+        result = load_status(temp_config_dir)
+        assert result is None
+
+
+class TestCliGroup:
+    """Tests for the main CLI group."""
+
+    def test_cli_shows_help_without_command(self, runner, temp_config_dir):
+        """Test that CLI shows help when no command is given."""
+        result = runner.invoke(cli, ["-c", str(temp_config_dir / "config.yaml")])
+        assert result.exit_code == 0
+        assert "Massalia Events Crawler" in result.output
+        assert "Commands:" in result.output
+
+    def test_cli_version(self, runner, temp_config_dir):
+        """Test --version flag."""
+        result = runner.invoke(
+            cli, ["-c", str(temp_config_dir / "config.yaml"), "--version"]
+        )
+        assert result.exit_code == 0
+        assert "massalia-crawler" in result.output
+        assert "1.0.0" in result.output
+
+    def test_cli_help(self, runner, temp_config_dir):
+        """Test --help flag."""
+        result = runner.invoke(
+            cli, ["-c", str(temp_config_dir / "config.yaml"), "--help"]
+        )
+        assert result.exit_code == 0
+        assert "Commands:" in result.output
+        assert "run" in result.output
+        assert "list-sources" in result.output
+        assert "validate" in result.output
+        assert "status" in result.output
+        assert "clean" in result.output
+
+
+class TestListSourcesCommand:
+    """Tests for the list-sources command."""
+
+    def test_list_sources(self, runner, temp_config_dir):
+        """Test list-sources command output."""
+        result = runner.invoke(
+            cli, ["-c", str(temp_config_dir / "config.yaml"), "list-sources"]
+        )
+        assert result.exit_code == 0
+        assert "Configured sources:" in result.output
+        assert "test-source" in result.output
+        assert "Test Source" in result.output
+        assert "generic" in result.output
+        assert "enabled" in result.output
+
+
+class TestValidateCommand:
+    """Tests for the validate command."""
+
+    def test_validate_valid_config(self, runner, temp_config_dir):
+        """Test validate command with valid config."""
+        result = runner.invoke(
+            cli, ["-c", str(temp_config_dir / "config.yaml"), "validate"]
+        )
+        # May have warnings but should pass
+        assert "Validating configuration files..." in result.output
+        assert "config.yaml is valid" in result.output
+
+    def test_validate_missing_sources_file(self, runner, temp_config_dir):
+        """Test validate when sources file is missing."""
+        # Remove sources file
+        (temp_config_dir / "config" / "sources.yaml").unlink()
+
+        result = runner.invoke(
+            cli, ["-c", str(temp_config_dir / "config.yaml"), "validate"]
+        )
+        assert result.exit_code == 1
+        assert "VALIDATION FAILED" in result.output
+
+
+class TestStatusCommand:
+    """Tests for the status command."""
+
+    def test_status_no_previous_run(self, runner, temp_config_dir):
+        """Test status command when no previous crawl."""
+        result = runner.invoke(
+            cli, ["-c", str(temp_config_dir / "config.yaml"), "status"]
+        )
+        assert result.exit_code == 0
+        assert "No previous crawl status found" in result.output
+
+    def test_status_with_previous_run(self, runner, temp_config_dir):
+        """Test status command after a crawl."""
+        # Save status
+        status = {
+            "sources_processed": 2,
+            "sources_total": 3,
+            "events_accepted": 15,
+            "events_rejected": 5,
+            "errors": 0,
+            "dry_run": False,
+            "interrupted": False,
+        }
+        save_status(temp_config_dir, status)
+
+        result = runner.invoke(
+            cli, ["-c", str(temp_config_dir / "config.yaml"), "status"]
+        )
+        assert result.exit_code == 0
+        assert "LAST CRAWL STATUS" in result.output
+        assert "Sources processed:  2/3" in result.output
+        assert "Events accepted:    15" in result.output
+        assert "SUCCESS" in result.output
+
+    def test_status_with_errors(self, runner, temp_config_dir):
+        """Test status command shows errors correctly."""
+        status = {
+            "sources_processed": 2,
+            "sources_total": 3,
+            "events_accepted": 10,
+            "events_rejected": 0,
+            "errors": 2,
+            "dry_run": False,
+            "interrupted": False,
+        }
+        save_status(temp_config_dir, status)
+
+        result = runner.invoke(
+            cli, ["-c", str(temp_config_dir / "config.yaml"), "status"]
+        )
+        assert result.exit_code == 0
+        assert "COMPLETED WITH ERRORS" in result.output
+
+
+class TestCleanCommand:
+    """Tests for the clean command."""
+
+    def test_clean_dry_run(self, runner, temp_config_dir):
+        """Test clean command with --dry-run."""
+        # Create an old event file
+        events_dir = temp_config_dir / "content" / "events" / "2020" / "01" / "01"
+        events_dir.mkdir(parents=True)
+        event_file = events_dir / "old-event.md"
+
+        front_matter = {
+            "title": "Old Event",
+            "date": "2020-01-01T10:00:00+01:00",
+            "name": "Old Event",
+            "expired": False,
+        }
+        content = "---\n" + yaml.dump(front_matter) + "---\n\nEvent description"
+        event_file.write_text(content)
+
+        result = runner.invoke(
+            cli, ["-c", str(temp_config_dir / "config.yaml"), "clean", "--dry-run"]
+        )
+        assert result.exit_code == 0
+        assert "DRY RUN MODE" in result.output
+        assert (
+            "old-event.md" in result.output
+            or "Would have marked expired: 1" in result.output
+        )
+
+        # File should still exist and not be modified
+        assert event_file.exists()
+        content = event_file.read_text()
+        assert "expired: false" in content.lower() or "expired: False" in content
+
+    def test_clean_marks_expired(self, runner, temp_config_dir):
+        """Test clean command marks events as expired."""
+        # Create an old event file
+        events_dir = temp_config_dir / "content" / "events" / "2020" / "01" / "01"
+        events_dir.mkdir(parents=True)
+        event_file = events_dir / "old-event.md"
+
+        front_matter = {
+            "title": "Old Event",
+            "date": "2020-01-01T10:00:00+01:00",
+            "name": "Old Event",
+            "expired": False,
+        }
+        content = "---\n" + yaml.dump(front_matter) + "---\n\nEvent description"
+        event_file.write_text(content)
+
+        result = runner.invoke(
+            cli, ["-c", str(temp_config_dir / "config.yaml"), "clean"]
+        )
+        assert result.exit_code == 0
+        assert (
+            "Marked expired:" in result.output
+            or "Events marked expired: 1" in result.output
+        )
+
+        # Check file was modified
+        content = event_file.read_text()
+        assert "expired: true" in content.lower()
+
+    def test_clean_delete(self, runner, temp_config_dir):
+        """Test clean command with --delete flag."""
+        # Create an old event file
+        events_dir = temp_config_dir / "content" / "events" / "2020" / "01" / "01"
+        events_dir.mkdir(parents=True)
+        event_file = events_dir / "old-event.md"
+
+        front_matter = {
+            "title": "Old Event",
+            "date": "2020-01-01T10:00:00+01:00",
+            "name": "Old Event",
+            "expired": False,
+        }
+        content = "---\n" + yaml.dump(front_matter) + "---\n\nEvent description"
+        event_file.write_text(content)
+
+        result = runner.invoke(
+            cli, ["-c", str(temp_config_dir / "config.yaml"), "clean", "--delete"]
+        )
+        assert result.exit_code == 0
+
+        # File should be deleted
+        assert not event_file.exists()
+
+    def test_clean_before_date(self, runner, temp_config_dir):
+        """Test clean command with --before flag."""
+        # Create events at different dates
+        for year, month, day in [(2020, 1, 1), (2025, 6, 15)]:
+            events_dir = (
+                temp_config_dir
+                / "content"
+                / "events"
+                / str(year)
+                / f"{month:02d}"
+                / f"{day:02d}"
+            )
+            events_dir.mkdir(parents=True)
+            event_file = events_dir / f"event-{year}.md"
+
+            front_matter = {
+                "title": f"Event {year}",
+                "date": f"{year}-{month:02d}-{day:02d}T10:00:00+01:00",
+                "name": f"Event {year}",
+                "expired": False,
+            }
+            content = "---\n" + yaml.dump(front_matter) + "---\n\nEvent description"
+            event_file.write_text(content)
+
+        result = runner.invoke(
+            cli,
+            [
+                "-c",
+                str(temp_config_dir / "config.yaml"),
+                "clean",
+                "--before",
+                "2025-01-01",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0
+        # Only 2020 event should be cleaned
+        assert (
+            "event-2020.md" in result.output
+            or "Would have marked expired: 1" in result.output
+        )
+
+
+class TestRunCommand:
+    """Tests for the run command."""
+
+    def test_run_help(self, runner, temp_config_dir):
+        """Test run command help."""
+        result = runner.invoke(
+            cli, ["-c", str(temp_config_dir / "config.yaml"), "run", "--help"]
+        )
+        assert result.exit_code == 0
+        assert "--source" in result.output
+        assert "--dry-run" in result.output
+        assert "--skip-selection" in result.output
+
+    def test_run_source_not_found(self, runner, temp_config_dir):
+        """Test run with nonexistent source."""
+        result = runner.invoke(
+            cli,
+            [
+                "-c",
+                str(temp_config_dir / "config.yaml"),
+                "run",
+                "--source",
+                "nonexistent",
+            ],
+        )
+        assert result.exit_code == 1
+        assert (
+            "No source found" in result.output or "not found" in result.output.lower()
+        )
+
+
+class TestSetupLoggingFromConfig:
+    """Tests for setup_logging_from_config function."""
+
+    def test_setup_logging_defaults(self, temp_config_dir):
+        """Test logging setup with defaults."""
+        config = {"logging": {"log_level": "INFO"}}
+        # Should not raise
+        setup_logging_from_config(config, temp_config_dir)
+
+    def test_setup_logging_override(self, temp_config_dir):
+        """Test logging setup with CLI override."""
+        config = {"logging": {"log_level": "INFO"}}
+        # Should not raise
+        setup_logging_from_config(config, temp_config_dir, log_level_override="DEBUG")
+
+    def test_setup_logging_backwards_compatibility(self, temp_config_dir):
+        """Test logging setup with old flat config format."""
+        config = {"log_level": "WARNING"}  # Old format
+        # Should not raise
+        setup_logging_from_config(config, temp_config_dir)


### PR DESCRIPTION
## Summary

- Implements Issue #26: Build command-line interface for crawler management
- Refactored CLI from a single command to Click groups with subcommands
- Added all requested commands: `run`, `list-sources`, `validate`, `status`, `clean`
- Added progress display and graceful interrupt handling
- Added comprehensive test coverage (22 new tests)
- Updated README with complete CLI documentation

## Commands

| Command | Description |
|---------|-------------|
| `run` | Execute crawler for all/specific sources |
| `list-sources` | Show configured event sources |
| `validate` | Check configuration for errors |
| `status` | Show last crawl results |
| `clean` | Mark old events as expired |

## Features

- **Progress display**: Shows `[1/6] Processing: Source Name (source-id)` during crawl
- **Keyboard interrupt**: Ctrl+C stops gracefully with partial results saved
- **Status tracking**: Saves crawl results to `.crawl_status.json`
- **Exit codes**: 0 for success, 1 for errors, 130 for interrupt
- **Help text**: Running without arguments shows help

## Usage Examples

```bash
# Show help
python crawl.py

# Run full crawl
python crawl.py run

# Preview mode
python crawl.py run --dry-run

# Specific source
python crawl.py run --source lafriche

# List sources
python crawl.py list-sources

# Validate config
python crawl.py validate

# Show last run status
python crawl.py status

# Clean expired events
python crawl.py clean --before 2026-01-01
```

## Test plan

- [x] All 334 tests pass (22 new CLI tests)
- [x] Code passes ruff linting and formatting
- [x] Manual testing of all commands
- [ ] Verify keyboard interrupt handling

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)