### PR TITLE
Implement event expiration system to hide past events

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ massalia.events is a static website that aggregates cultural events from multipl
 - Automatic categorization (danse, musique, theatre, art, communaute)
 - Location-based filtering (Marseille area)
 - Multi-day event support
+- Automatic event expiration (past events hidden from public view)
 - Optimized images in WebP format
 - French language support
 
@@ -217,6 +218,42 @@ make cleanup           # Remove stale artifacts
 | expire-events.sh | `--mark` | Add expired: true to past events |
 | expire-events.sh | `--delete` | Remove past events and images |
 | expire-events.sh | `--days N` | Events older than N days |
+
+## Event Expiration System
+
+Past events are automatically hidden from the public website while remaining in the content repository for historical reference.
+
+### How It Works
+
+1. **Expiration Flag**: Each event has an `expired: false` field in its front matter
+2. **Timezone**: Events expire at midnight Europe/Paris time after the event date
+3. **Display**: Expired events are filtered from all listings (home, categories, tags, search)
+4. **Direct Access**: Accessing an expired event URL shows a friendly "Cet événement est passé" message
+5. **Preservation**: Expired event files remain in `/content/events/` for Git history
+
+### Managing Expired Events
+
+```bash
+# List past events
+make expire-events
+
+# Mark past events as expired
+make mark-expired
+
+# Or use the script directly
+./scripts/maintenance/expire-events.sh --mark
+
+# Delete events older than 30 days
+./scripts/maintenance/expire-events.sh --delete --days 30
+```
+
+### Event Front Matter
+
+New events created by the crawler include:
+```yaml
+expired: false
+expiryDate: 2026-01-28T00:00:00+01:00  # Hugo's built-in expiry
+```
 
 ## Technology Stack
 

--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -1,0 +1,41 @@
+{{/*
+  Custom search index that excludes expired events
+  This overrides the Blowfish default to filter out expired: true pages
+*/}}
+{{- $index := slice -}}
+{{ $pages := .Site.Pages }}
+{{ range .Site.Home.Translations }}
+{{ $pages = $pages | lang.Merge .Site.Pages }}
+{{ end }}
+{{- range $pages -}}
+  {{/* Skip pages marked for exclusion from search */}}
+  {{- if not .Params.excludeFromSearch -}}
+    {{/* Skip expired events */}}
+    {{- if not .Params.expired -}}
+      {{- $section := .Site.GetPage "section" .Section -}}
+      {{- if .Date -}}
+        {{- $index = $index | append (dict
+        "date" (.Date | time.Format (.Site.Language.Params.dateFormat | default ":date_long"))
+        "title" (.Title | emojify | safeJS)
+        "section" ($section.Title | emojify | safeJS)
+        "summary" (.Summary | plainify | htmlUnescape | safeJS)
+        "content" (.Plain | safeJS)
+        "permalink" .RelPermalink
+        "externalUrl" .Params.externalUrl
+        "type" .Type
+        ) -}}
+      {{- else -}}
+        {{- $index = $index | append (dict
+        "title" (.Title | emojify | safeJS)
+        "section" ($section.Title | emojify | safeJS)
+        "summary" (.Summary | plainify | htmlUnescape | safeJS)
+        "content" (.Plain | safeJS)
+        "permalink" .RelPermalink
+        "externalUrl" .Params.externalUrl
+        "type" .Type
+        ) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $index | jsonify -}}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,0 +1,126 @@
+{{ define "main" }}
+{{/*
+  Taxonomy term page - shows pages for a specific term (e.g., /categories/danse/)
+  This overrides the Blowfish default to filter out expired events
+*/}}
+
+{{ .Scratch.Set "scope" "list" }}
+{{ $enableToc := .Params.showTableOfContents | default (site.Params.term.showTableOfContents | default false) }}
+{{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
+
+{{/* Hero */}}
+{{ if site.Params.term.showHero | default false }}
+  {{ $heroStyle := print "hero/" site.Params.term.heroStyle ".html" }}
+  {{ if templates.Exists ( printf "partials/%s" $heroStyle ) }}
+    {{ partial $heroStyle . }}
+  {{ else }}
+    {{ partial "hero/basic.html" . }}
+  {{ end }}
+{{ end }}
+
+{{/* Header */}}
+<header>
+  {{ if .Params.showBreadcrumbs | default (site.Params.term.showBreadcrumbs | default false) }}
+    {{ partial "breadcrumbs.html" . }}
+  {{ end }}
+  <h1 class="mt-5 text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Title }}</h1>
+  <div class="mt-1 mb-2 text-base text-neutral-500 dark:text-neutral-400 print:hidden">
+    {{ partial "article-meta/list.html" (dict "context" . "scope" "single") }}
+  </div>
+</header>
+
+{{/* Description (markdown content) */}}
+{{ $tocMargin := cond $showToc "mt-12" "mt-0" }}
+{{ $topClass := cond (hasPrefix site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
+<section class="{{ $tocMargin }} prose flex max-w-full flex-col dark:prose-invert lg:flex-row mb-10">
+  {{ if $showToc }}
+    <div class="order-first lg:ms-auto px-0 lg:order-last lg:ps-8 lg:max-w-2xs">
+      <div class="toc ps-5 print:hidden lg:sticky {{ $topClass }}">
+        {{ partial "toc.html" . }}
+      </div>
+    </div>
+  {{ end }}
+  <div class="min-w-0 min-h-0 max-w-prose w-full">
+    {{ .Content }}
+  </div>
+</section>
+
+{{/* Filter expired events */}}
+{{ $allPages := .Pages }}
+{{ $activeEvents := partial "filter-active-events.html" (dict "pages" $allPages) }}
+
+{{/* Article Grid */}}
+{{ if gt (len $activeEvents) 0 }}
+  {{ $cardView := .Params.cardView | default (site.Params.term.cardView | default false) }}
+  {{ $cardViewScreenWidth := .Params.cardViewScreenWidth | default (site.Params.term.cardViewScreenWidth | default false) }}
+  {{ $groupByYear := .Params.groupByYear | default (site.Params.term.groupByYear | default false) }}
+
+  {{ if not $cardView }}
+    <section class="space-y-10 w-full">
+      {{ range ($activeEvents.GroupByDate "2006") }}
+        {{ if $groupByYear }}
+          <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+            {{ .Key }}
+          </h2>
+        {{ end }}
+        {{ range .Pages }}
+          {{ partial "article-link/simple.html" . }}
+        {{ end }}
+      {{ end }}
+    </section>
+  {{ else }}
+    {{ if $groupByYear }}
+      {{ range ($activeEvents.GroupByDate "2006") }}
+        {{ if $cardViewScreenWidth }}
+          <div class="relative w-screen max-w-[1600px] px-[30px] start-[calc(max(-50vw,-800px)+50%)]">
+            <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+              {{ .Key }}
+            </h2>
+            <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+              {{ range .Pages }}
+                {{ partial "article-link/card.html" . }}
+              {{ end }}
+            </section>
+          </div>
+        {{ else }}
+          <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+            {{ .Key }}
+          </h2>
+          <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+            {{ range .Pages }}
+              {{ partial "article-link/card.html" . }}
+            {{ end }}
+          </section>
+        {{ end }}
+      {{ end }}
+    {{ else }}
+      {{ if $cardViewScreenWidth }}
+        <div class="relative w-screen max-w-[1600px] px-[30px] start-[calc(max(-50vw,-800px)+50%)]">
+          <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+            {{ range ($activeEvents.GroupByDate "2006") }}
+              {{ range .Pages }}
+                {{ partial "article-link/card.html" . }}
+              {{ end }}
+            {{ end }}
+          </section>
+        </div>
+      {{ else }}
+        <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+          {{ range ($activeEvents.GroupByDate "2006") }}
+            {{ range .Pages }}
+              {{ partial "article-link/card.html" . }}
+            {{ end }}
+          {{ end }}
+        </section>
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ else }}
+  <section class="mt-10 prose dark:prose-invert">
+    <p class="py-8 border-t">
+      <em>{{ i18n "list.no_articles" | default "Aucun événement à venir" | emojify }}</em>
+    </p>
+  </section>
+{{ end }}
+{{ partial "pagination.html" . }}
+{{ end }}

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -1,0 +1,150 @@
+{{ define "main" }}
+{{/*
+  Events list page - shows all non-expired events
+  This overrides the default Blowfish list template to filter expired events
+*/}}
+
+{{ .Scratch.Set "scope" "list" }}
+{{ $enableToc := .Params.showTableOfContents | default (site.Params.list.showTableOfContents | default false) }}
+{{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
+
+{{/* Hero */}}
+{{ if site.Params.list.showHero | default false }}
+  {{ $heroStyle := print "hero/" site.Params.list.heroStyle ".html" }}
+  {{ if templates.Exists ( printf "partials/%s" $heroStyle ) }}
+    {{ partial $heroStyle . }}
+  {{ else }}
+    {{ partial "hero/basic.html" . }}
+  {{ end }}
+{{ end }}
+
+{{/* Header */}}
+<header>
+  {{ if .Params.showBreadcrumbs | default (site.Params.list.showBreadcrumbs | default false) }}
+    {{ partial "breadcrumbs.html" . }}
+  {{ end }}
+  <h1 class="mt-5 text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Title }}</h1>
+  <div class="mt-1 mb-2 text-base text-neutral-500 dark:text-neutral-400 print:hidden">
+    {{ partial "article-meta/list.html" (dict "context" . "scope" "single") }}
+  </div>
+</header>
+
+{{/* Description (markdown content) */}}
+{{ $tocMargin := cond $showToc "mt-12" "mt-0" }}
+{{ $topClass := cond (hasPrefix site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
+<section class="{{ $tocMargin }} prose flex max-w-full flex-col dark:prose-invert lg:flex-row mb-10">
+  {{ if $showToc }}
+    <div class="order-first lg:ms-auto px-0 lg:order-last lg:ps-8 lg:max-w-2xs">
+      <div class="toc ps-5 print:hidden lg:sticky {{ $topClass }}">
+        {{ partial "toc.html" . }}
+      </div>
+    </div>
+  {{ end }}
+  <div class="min-w-0 min-h-0 max-w-prose w-full">
+    {{ .Content }}
+  </div>
+</section>
+
+{{/* Filter expired events using our custom partial */}}
+{{ $allPages := .Pages }}
+{{ $activeEvents := partial "filter-active-events.html" (dict "pages" $allPages) }}
+
+{{/* Article Grid */}}
+{{ if gt (len $activeEvents) 0 }}
+  {{ $cardView := .Params.cardView | default (site.Params.list.cardView | default false) }}
+  {{ $cardViewScreenWidth := .Params.cardViewScreenWidth | default (site.Params.list.cardViewScreenWidth | default false) }}
+  {{ $groupByYear := .Params.groupByYear | default (site.Params.list.groupByYear | default false) }}
+  {{ $orderByWeight := .Params.orderByWeight | default (site.Params.list.orderByWeight | default false) }}
+  {{ $groupByYear := and (not $orderByWeight) $groupByYear }}
+
+  {{ if not $cardView }}
+    <section class="space-y-10 w-full">
+      {{ if not $orderByWeight }}
+        {{ range ($activeEvents.GroupByDate "2006") }}
+          {{ if $groupByYear }}
+            <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+              {{ .Key }}
+            </h2>
+          {{ end }}
+          {{ range .Pages }}
+            {{ partial "article-link/simple.html" . }}
+          {{ end }}
+        {{ end }}
+      {{ else }}
+        {{ range $activeEvents.ByWeight }}
+          {{ partial "article-link/simple.html" . }}
+        {{ end }}
+      {{ end }}
+    </section>
+  {{/* else: is cardView */}}
+  {{ else }}
+    {{ if $groupByYear }}
+      {{ range ($activeEvents.GroupByDate "2006") }}
+        {{ if $cardViewScreenWidth }}
+          <div class="relative w-screen max-w-[1600px] px-[30px] start-[calc(max(-50vw,-800px)+50%)]">
+            <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+              {{ .Key }}
+            </h2>
+            <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+              {{ range .Pages }}
+                {{ partial "article-link/card.html" . }}
+              {{ end }}
+            </section>
+          </div>
+        {{ else }}
+          <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+            {{ .Key }}
+          </h2>
+          <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+            {{ range .Pages }}
+              {{ partial "article-link/card.html" . }}
+            {{ end }}
+          </section>
+        {{ end }}
+      {{ end }}
+
+    {{/* else: not groupByYear */}}
+    {{ else }}
+      {{ if $cardViewScreenWidth }}
+        <div class="relative w-screen max-w-[1600px] px-[30px] start-[calc(max(-50vw,-800px)+50%)]">
+          <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+            {{ if not $orderByWeight }}
+              {{ range ($activeEvents.GroupByDate "2006") }}
+                {{ range .Pages }}
+                  {{ partial "article-link/card.html" . }}
+                {{ end }}
+              {{ end }}
+            {{ else }}
+              {{ range $activeEvents.ByWeight }}
+                {{ partial "article-link/card.html" . }}
+              {{ end }}
+            {{ end }}
+          </section>
+        </div>
+      {{ else }}
+        <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+          {{ if not $orderByWeight }}
+            {{ range ($activeEvents.GroupByDate "2006") }}
+              {{ range .Pages }}
+                {{ partial "article-link/card.html" . }}
+              {{ end }}
+            {{ end }}
+          {{ else }}
+            {{ range $activeEvents.ByWeight }}
+              {{ partial "article-link/card.html" . }}
+            {{ end }}
+          {{ end }}
+        </section>
+      {{ end }}{{/* End of cardViewScreenWidth */}}
+    {{ end }}{{/* End of groupByYear */}}
+  {{ end }}{{/* End of cardView */}}
+{{/* else: no active events */}}
+{{ else }}
+  <section class="mt-10 prose dark:prose-invert">
+    <p class="py-8 border-t">
+      <em>{{ i18n "list.no_articles" | default "Aucun événement à venir" | emojify }}</em>
+    </p>
+  </section>
+{{ end }}
+{{ partial "pagination.html" . }}
+{{ end }}

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -1,6 +1,41 @@
 {{ define "main" }}
 {{/* Event detail page template */}}
 {{ $page := . }}
+
+{{/* Check if event is expired */}}
+{{ if $page.Params.expired }}
+  {{/* Display expired event message */}}
+  <article class="event-expired max-w-4xl mx-auto py-16 text-center">
+    {{/* Back navigation */}}
+    <nav class="mb-8">
+      <a href="/" class="inline-flex items-center gap-2 text-sm font-medium text-neutral-600 hover:text-primary-500 dark:text-neutral-400 dark:hover:text-primary-400 transition-colors">
+        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+        </svg>
+        Retour aux événements
+      </a>
+    </nav>
+
+    {{/* Expired message */}}
+    <div class="mx-auto w-20 h-20 mb-6 rounded-full bg-neutral-100 dark:bg-neutral-800 flex items-center justify-center">
+      <svg class="h-10 w-10 text-neutral-400 dark:text-neutral-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    </div>
+    <h1 class="text-3xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
+      Cet événement est passé
+    </h1>
+    <p class="text-lg text-neutral-600 dark:text-neutral-400 mb-8 max-w-md mx-auto">
+      L'événement « {{ $page.Params.name | default $page.Title }} » a eu lieu le {{ $page.Date.Format "2 January 2006" }}.
+    </p>
+    <a href="/" class="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-primary-500 text-white font-semibold hover:bg-primary-600 transition-colors">
+      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+      </svg>
+      Voir les prochains événements
+    </a>
+  </article>
+{{ else }}
 {{ $disableImageOptimization := site.Params.disableImageOptimization | default false }}
 
 {{/* French day names (0=Sunday through 6=Saturday) */}}
@@ -314,4 +349,5 @@
   "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode"
 }
 </script>
+{{ end }}{{/* End of non-expired event display */}}
 {{ end }}

--- a/layouts/partials/filter-active-events.html
+++ b/layouts/partials/filter-active-events.html
@@ -1,0 +1,23 @@
+{{/*
+  filter-active-events.html - Filter out expired events from a page collection
+
+  Usage:
+    {{ $activeEvents := partial "filter-active-events.html" (dict "pages" .Pages) }}
+    {{ range $activeEvents }}...{{ end }}
+
+  This partial filters out:
+    - Pages with expired: true in front matter
+    - Draft pages (unless buildDrafts is enabled)
+
+  Returns: A slice of active (non-expired) event pages
+*/}}
+
+{{- $pages := .pages -}}
+
+{{/* Filter out expired events */}}
+{{- $activeEvents := where $pages ".Params.expired" "!=" true -}}
+
+{{/* Also filter out drafts for safety */}}
+{{- $activeEvents = where $activeEvents ".Draft" false -}}
+
+{{- return $activeEvents -}}


### PR DESCRIPTION
## Summary

Implements the event expiration system as specified in the product requirements. Past events are hidden from public display while remaining in the content repository for historical reference.

### Changes

**Hugo Templates:**
- Create `layouts/partials/filter-active-events.html` - Reusable partial to filter out expired events
- Create `layouts/events/list.html` - Override to filter event section listings
- Create `layouts/_default/term.html` - Override to filter taxonomy pages (categories, locations, tags, dates)
- Create `layouts/_default/index.json` - Override to exclude expired events from search index
- Update `layouts/events/single.html` - Show friendly French message for expired events

**Expiration Script:**
- Update `scripts/maintenance/expire-events.sh` with Europe/Paris timezone handling
- Events expire at midnight Paris time after the event date

**Documentation:**
- Update README with event expiration system documentation

### How Expiration Works

1. Each event has `expired: false` field in front matter (set by crawler)
2. Events expire at midnight Europe/Paris time after the event date
3. Expired events filtered from: homepage, category pages, location pages, tag pages, date pages, search
4. Direct URLs to expired events show: "Cet événement est passé"
5. Expired event files remain in `/content/events/` for Git history

### Existing Support

The archetype and crawler already include expiration fields:
- `expired: false` - Manual expiration flag
- `expiryDate` - Hugo's built-in page expiry

## Test plan

- [x] Hugo builds successfully with new templates
- [x] All crawler tests pass (334 tests)
- [x] Linter passes
- [x] `expire-events.sh` runs with timezone info
- [x] Homepage filters expired events (existing logic)
- [ ] Expired event shows French message when accessed directly
- [ ] Search excludes expired events
- [ ] Category/location/tag pages filter expired events

## Files Changed

| File | Purpose |
|------|---------|
| `layouts/partials/filter-active-events.html` | Reusable filter partial |
| `layouts/events/list.html` | Event section list override |
| `layouts/events/single.html` | Expired event message |
| `layouts/_default/term.html` | Taxonomy term page override |
| `layouts/_default/index.json` | Search index override |
| `scripts/maintenance/expire-events.sh` | Timezone handling |
| `README.md` | Expiration documentation |

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)