### PR TITLE
Fix content deployment by adding untracked event files

### DIFF
--- a/content/events/2026/01/27/coeur-avec-les-doigts.fr.md
+++ b/content/events/2026/01/27/coeur-avec-les-doigts.fr.md
@@ -1,0 +1,37 @@
+---
+title: Cœur avec les doigts
+date: '2026-01-27T19:00:00+01:00'
+draft: false
+expiryDate: '2026-01-28T00:00:00+01:00'
+name: Cœur avec les doigts
+eventURL: https://www.lafriche.org/evenements/coeur-avec-les-doigts/
+startTime: '19:00'
+description: 'Tarif Plein adulte/enfant : 10€.
+
+  Tarif Carte Massalia adulte/enfant : 7€.
+
+  Carte Massalia : 15€.
+
+  Carte Massalia Solidaire (bénéficiaires du RSA) : 15€, ce...'
+categories:
+- theatre
+locations:
+- la-friche
+dates:
+- mardi-27-janvier
+tags:
+- théâtre
+- danse
+- atelier /stage
+- musique son
+- performance
+image: /images/events/coeur-avec-les-doigts-1b17780d.webp
+sourceId: lafriche:coeur-avec-les-doigts
+lastCrawled: '2026-01-27T11:38:27+01:00'
+expired: false
+---
+
+Tarif Plein adulte/enfant : 10€.
+Tarif Carte Massalia adulte/enfant : 7€.
+Carte Massalia : 15€.
+Carte Massalia Solidaire (bénéficiaires du RSA) : 15€, ce...

--- a/content/events/2026/01/30/club-cabaret.fr.md
+++ b/content/events/2026/01/30/club-cabaret.fr.md
@@ -1,0 +1,28 @@
+---
+title: Club Cabaret
+date: '2026-01-30T20:00:00+01:00'
+draft: false
+expiryDate: '2026-01-31T00:00:00+01:00'
+name: Club Cabaret
+eventURL: https://www.lafriche.org/evenements/club-cabaret-9/
+startTime: '20:00'
+description: Depuis plus de 10 ans, c’est LE rendez-vous hebdomadaire des découvertes musicales et du soutien à la scène locale marseillaise.
+categories:
+- musique
+locations:
+- la-friche
+dates:
+- vendredi-30-janvier
+tags:
+- musique son
+- exposition
+- rencontre
+- performance
+- cuisine
+image: /images/events/club-cabaret-a95bffba.webp
+sourceId: lafriche:club-cabaret-9
+lastCrawled: '2026-01-27T11:38:46+01:00'
+expired: false
+---
+
+Depuis plus de 10 ans, c’est LE rendez-vous hebdomadaire des découvertes musicales et du soutien à la scène locale marseillaise.

--- a/content/events/2026/01/30/collective-shoes.fr.md
+++ b/content/events/2026/01/30/collective-shoes.fr.md
@@ -1,0 +1,28 @@
+---
+title: Collective Shoes
+date: '2026-01-30T17:00:00+01:00'
+draft: false
+expiryDate: '2026-01-31T00:00:00+01:00'
+name: Collective Shoes
+eventURL: https://www.lafriche.org/evenements/collective-shoes/
+startTime: '17:00'
+description: 'Les 25 artistes invité·es à participer à cette exposition ont toustes répondu à un protocole commun : l’œuvre ou le projet exposé devra tenir dans une boite...'
+categories:
+- art
+locations:
+- la-friche
+dates:
+- vendredi-30-janvier
+tags:
+- exposition
+- musique son
+- rencontre
+- performance
+- cuisine
+image: /images/events/collective-shoes-5da61ddc.webp
+sourceId: lafriche:collective-shoes
+lastCrawled: '2026-01-27T11:38:43+01:00'
+expired: false
+---
+
+Les 25 artistes invité·es à participer à cette exposition ont toustes répondu à un protocole commun : l’œuvre ou le projet exposé devra tenir dans une boite...

--- a/content/events/2026/01/30/le-gue-culture-sous-guerre.fr.md
+++ b/content/events/2026/01/30/le-gue-culture-sous-guerre.fr.md
@@ -1,0 +1,28 @@
+---
+title: Le Gué – Culture sous guerre
+date: '2026-01-30T17:00:00+01:00'
+draft: false
+expiryDate: '2026-01-31T00:00:00+01:00'
+name: Le Gué – Culture sous guerre
+eventURL: https://www.lafriche.org/evenements/le-gue-culture-sous-guerre/
+startTime: '17:00'
+description: 'Commissariat : UUS Studio, Paul Gilonne.'
+categories:
+- art
+locations:
+- la-friche
+dates:
+- vendredi-30-janvier
+tags:
+- exposition
+- musique son
+- rencontre
+- performance
+- cuisine
+image: /images/events/le-gue-culture-sous-guerre-b6e4ac56.webp
+sourceId: lafriche:le-gue-culture-sous-guerre
+lastCrawled: '2026-01-27T11:38:26+01:00'
+expired: false
+---
+
+Commissariat : UUS Studio, Paul Gilonne.

--- a/content/events/2026/01/30/lives-et-dj-sets.fr.md
+++ b/content/events/2026/01/30/lives-et-dj-sets.fr.md
@@ -1,0 +1,28 @@
+---
+title: Lives et Dj sets
+date: '2026-01-30T20:00:00+01:00'
+draft: false
+expiryDate: '2026-01-31T00:00:00+01:00'
+name: Lives et Dj sets
+eventURL: https://www.lafriche.org/evenements/lives-et-dj-sets/
+startTime: '20:00'
+description: Le Festival Parallèle investit le Petit Cab pour célébrer l’émergence avec deux lives et deux DJ sets pour nous réchauffer en plein hiver.
+categories:
+- musique
+locations:
+- la-friche
+dates:
+- vendredi-30-janvier
+tags:
+- musique son
+- exposition
+- rencontre
+- performance
+- cuisine
+image: /images/events/lives-et-dj-sets-f1f86392.webp
+sourceId: lafriche:lives-et-dj-sets
+lastCrawled: '2026-01-27T11:38:47+01:00'
+expired: false
+---
+
+Le Festival Parallèle investit le Petit Cab pour célébrer l’émergence avec deux lives et deux DJ sets pour nous réchauffer en plein hiver.

--- a/content/events/2026/01/30/rencontre-la-culture-contre-attaque.fr.md
+++ b/content/events/2026/01/30/rencontre-la-culture-contre-attaque.fr.md
@@ -1,0 +1,28 @@
+---
+title: Rencontre ‘La Culture contre-attaque’
+date: '2026-01-30T17:00:00+01:00'
+draft: false
+expiryDate: '2026-01-31T00:00:00+01:00'
+name: Rencontre ‘La Culture contre-attaque’
+eventURL: https://www.lafriche.org/evenements/la-culture-contre-attaque/
+startTime: '17:00'
+description: À l’issue de deux jours de travail réunissant des opérateur·ices culturel·les français, ukrainien·nes et européen·nes, une session publique présentera les...
+categories:
+- communaute
+locations:
+- la-friche
+dates:
+- vendredi-30-janvier
+tags:
+- rencontre
+- musique son
+- exposition
+- performance
+- cuisine
+image: /images/events/rencontre-la-culture-contre-attaque-73e619f1.webp
+sourceId: lafriche:la-culture-contre-attaque
+lastCrawled: '2026-01-27T11:38:34+01:00'
+expired: false
+---
+
+À l’issue de deux jours de travail réunissant des opérateur·ices culturel·les français, ukrainien·nes et européen·nes, une session publique présentera les...

--- a/content/events/2026/01/30/soiree-de-vernissage.fr.md
+++ b/content/events/2026/01/30/soiree-de-vernissage.fr.md
@@ -1,0 +1,28 @@
+---
+title: Soirée de vernissage
+date: '2026-01-30T20:00:00+01:00'
+draft: false
+expiryDate: '2026-01-31T00:00:00+01:00'
+name: Soirée de vernissage
+eventURL: https://www.lafriche.org/evenements/le-voyage-en-ukraine-soiree-de-vernissage/
+startTime: '20:00'
+description: À l’occasion de la Saison de l’Ukraine en France rendez-vous à la Friche pour une soirée autour de l’inauguration de l’exposition Le Gué – Culture sous guerre.
+categories:
+- art
+locations:
+- la-friche
+dates:
+- vendredi-30-janvier
+tags:
+- exposition
+- musique son
+- rencontre
+- performance
+- cuisine
+image: /images/events/soiree-de-vernissage-d0d77413.webp
+sourceId: lafriche:le-voyage-en-ukraine-soiree-de-vernissage
+lastCrawled: '2026-01-27T11:38:40+01:00'
+expired: false
+---
+
+À l’occasion de la Saison de l’Ukraine en France rendez-vous à la Friche pour une soirée autour de l’inauguration de l’exposition Le Gué – Culture sous guerre.

--- a/content/events/2026/01/31/ascendant-vierge-presente-av-va.fr.md
+++ b/content/events/2026/01/31/ascendant-vierge-presente-av-va.fr.md
@@ -1,0 +1,25 @@
+---
+title: Ascendant Vierge présente AV/VA
+date: '2026-01-31T20:00:00+01:00'
+draft: false
+expiryDate: '2026-02-01T00:00:00+01:00'
+name: Ascendant Vierge présente AV/VA
+eventURL: https://www.lafriche.org/evenements/ascendant-vierge-presente-av-va/
+startTime: '20:00'
+description: Avec AV/VA (Ascendant Vierge Various Artists), ascendant vierge réaffirme son lien essentiel avec le club.
+categories:
+- musique
+locations:
+- la-friche
+dates:
+- samedi-31-janvier
+tags:
+- musique son
+- newsletter
+image: /images/events/ascendant-vierge-presente-av-va-1de0d134.webp
+sourceId: lafriche:ascendant-vierge-presente-av-va
+lastCrawled: '2026-01-27T11:38:44+01:00'
+expired: false
+---
+
+Avec AV/VA (Ascendant Vierge Various Artists), ascendant vierge réaffirme son lien essentiel avec le club.

--- a/content/events/2026/01/31/b-le-poids-du-ciel.fr.md
+++ b/content/events/2026/01/31/b-le-poids-du-ciel.fr.md
@@ -1,0 +1,28 @@
+---
+title: BаГа неба – Le poids du ciel
+date: '2026-01-31T18:00:00+01:00'
+draft: false
+expiryDate: '2026-02-01T00:00:00+01:00'
+name: BаГа неба – Le poids du ciel
+eventURL: https://www.lafriche.org/evenements/b%d0%b0%d0%b3%d0%b0-%d0%bd%d0%b5%d0%b1%d0%b0-le-poids-du-ciel/
+startTime: '18:00'
+description: Comment se nourrir en temps de guerre ? Comment faire à manger sans électricité ? Quelle place pour la nourriture dans les zones de conflit quand les bombes...
+categories:
+- art
+locations:
+- la-friche
+dates:
+- samedi-31-janvier
+tags:
+- cinéma vidéo
+- musique son
+- exposition
+- rencontre
+- performance
+image: /images/events/b-le-poids-du-ciel-3954c8c0.webp
+sourceId: lafriche:b%d0%b0%d0%b3%d0%b0-%d0%bd%d0%b5%d0%b1%d0%b0-le-poids-du-ciel
+lastCrawled: '2026-01-27T11:38:19+01:00'
+expired: false
+---
+
+Comment se nourrir en temps de guerre ? Comment faire à manger sans électricité ? Quelle place pour la nourriture dans les zones de conflit quand les bombes...

--- a/content/events/2026/01/31/dry31.fr.md
+++ b/content/events/2026/01/31/dry31.fr.md
@@ -1,0 +1,25 @@
+---
+title: DRY31
+date: '2026-01-31T20:00:00+01:00'
+draft: false
+expiryDate: '2026-02-01T00:00:00+01:00'
+name: DRY31
+eventURL: https://www.lafriche.org/evenements/dry31/
+startTime: '20:00'
+description: Le DRY 31 c’est quoi ? C’est la plus grande fête sans alcool de l’année dans plus de 50 lieux dans toute la France !
+categories:
+- musique
+locations:
+- la-friche
+dates:
+- samedi-31-janvier
+tags:
+- musique son
+- newsletter
+image: /images/events/dry31-512bff56.webp
+sourceId: lafriche:dry31
+lastCrawled: '2026-01-27T11:38:49+01:00'
+expired: false
+---
+
+Le DRY 31 c’est quoi ? C’est la plus grande fête sans alcool de l’année dans plus de 50 lieux dans toute la France !

--- a/content/events/2026/01/31/entrez-libres.fr.md
+++ b/content/events/2026/01/31/entrez-libres.fr.md
@@ -1,0 +1,27 @@
+---
+title: Entrez libres
+date: '2026-01-31T20:00:00+01:00'
+draft: false
+expiryDate: '2026-02-01T00:00:00+01:00'
+name: Entrez libres
+eventURL: https://www.lafriche.org/evenements/entrez-libres-7/
+startTime: '20:00'
+description: Cette année, le MédiaLab vous invite à plonger dans l’univers fascinant des jeux vidéo indépendants et artistiques. Chaque mois est dédié à une thématique...
+categories:
+- communaute
+locations:
+- la-friche
+dates:
+- samedi-31-janvier
+tags:
+- atelier /stage
+- numérique
+- événement passé
+- newsletter
+image: /images/events/entrez-libres-3b01960e.webp
+sourceId: lafriche:entrez-libres-7
+lastCrawled: '2026-01-27T11:38:20+01:00'
+expired: false
+---
+
+Cette année, le MédiaLab vous invite à plonger dans l’univers fascinant des jeux vidéo indépendants et artistiques. Chaque mois est dédié à une thématique...

--- a/content/events/2026/01/31/fetes-interconnectees-de-la-bd.fr.md
+++ b/content/events/2026/01/31/fetes-interconnectees-de-la-bd.fr.md
@@ -1,0 +1,28 @@
+---
+title: Fêtes interconnectées de la BD
+date: '2026-01-31T20:00:00+01:00'
+draft: false
+expiryDate: '2026-02-01T00:00:00+01:00'
+name: Fêtes interconnectées de la BD
+eventURL: https://www.lafriche.org/evenements/fetes-interconnectees-de-la-bd/
+startTime: '20:00'
+description: Marseille concentre un nombre grandissant d’artistes et de professionnels de la bande dessinée. Une soixantaine d’auteurices et d’éditeurices indépendant·es...
+categories:
+- art
+locations:
+- la-friche
+dates:
+- samedi-31-janvier
+tags:
+- exposition
+- atelier /stage
+- littérature édition
+- musique son
+- rencontre
+image: /images/events/fetes-interconnectees-de-la-bd-0872e29d.webp
+sourceId: lafriche:fetes-interconnectees-de-la-bd
+lastCrawled: '2026-01-27T11:38:35+01:00'
+expired: false
+---
+
+Marseille concentre un nombre grandissant d’artistes et de professionnels de la bande dessinée. Une soixantaine d’auteurices et d’éditeurices indépendant·es...

--- a/content/events/2026/01/31/les-oreilles-d-aman.fr.md
+++ b/content/events/2026/01/31/les-oreilles-d-aman.fr.md
@@ -1,0 +1,28 @@
+---
+title: Les Oreilles d’Aman
+date: '2026-01-31T19:00:00+01:00'
+draft: false
+expiryDate: '2026-02-01T00:00:00+01:00'
+name: Les Oreilles d’Aman
+eventURL: https://www.lafriche.org/evenements/les-oreilles-daman/
+startTime: '19:00'
+description: La musique des Oreilles d’Aman bouscule la mélancolie, rapproche jeunes et anciens, hommes et femmes, en faisant résonner des airs traditionnels yiddish qui...
+categories:
+- musique
+locations:
+- la-friche
+dates:
+- samedi-31-janvier
+tags:
+- musique son
+- exposition
+- rencontre
+- performance
+- cuisine
+image: /images/events/les-oreilles-d-aman-b6aa795d.webp
+sourceId: lafriche:les-oreilles-daman
+lastCrawled: '2026-01-27T11:38:29+01:00'
+expired: false
+---
+
+La musique des Oreilles d’Aman bouscule la mélancolie, rapproche jeunes et anciens, hommes et femmes, en faisant résonner des airs traditionnels yiddish qui...

--- a/content/events/2026/02/05/miki.fr.md
+++ b/content/events/2026/02/05/miki.fr.md
@@ -1,0 +1,28 @@
+---
+title: Miki
+date: '2026-02-05T20:00:00+01:00'
+draft: false
+expiryDate: '2026-02-06T00:00:00+01:00'
+name: Miki
+eventURL: https://www.lafriche.org/evenements/miki/
+startTime: '20:00'
+description: Une soirée Hyperpop avec MIKI et ROMSII au Grand Cab !
+categories:
+- musique
+locations:
+- la-friche
+dates:
+- jeudi-05-fevrier
+tags:
+- musique son
+- exposition
+- rencontre
+- performance
+- cuisine
+image: /images/events/miki-f2aedb77.webp
+sourceId: lafriche:miki
+lastCrawled: '2026-01-27T11:38:23+01:00'
+expired: false
+---
+
+Une soirée Hyperpop avec MIKI et ROMSII au Grand Cab !

--- a/content/events/2026/02/06/labo-des-desirs.fr.md
+++ b/content/events/2026/02/06/labo-des-desirs.fr.md
@@ -1,0 +1,28 @@
+---
+title: Labo des désirs
+date: '2026-02-06T20:00:00+01:00'
+draft: false
+expiryDate: '2026-02-07T00:00:00+01:00'
+name: Labo des désirs
+eventURL: https://www.lafriche.org/evenements/labo-des-desirs-3/
+startTime: '20:00'
+description: 'Le Labo des désirs est un lieu ouvert à tous·tes : frichistes, usager·es, habitant·es du quartier, où chacun·e apporte ses connaissances, ses talents ou ses...'
+categories:
+- theatre
+locations:
+- la-friche
+dates:
+- vendredi-06-fevrier
+tags:
+- théâtre
+- danse
+- atelier /stage
+- numérique
+- exposition
+image: /images/events/labo-des-desirs-605839ac.webp
+sourceId: lafriche:labo-des-desirs-3
+lastCrawled: '2026-01-27T11:38:24+01:00'
+expired: false
+---
+
+Le Labo des désirs est un lieu ouvert à tous·tes : frichistes, usager·es, habitant·es du quartier, où chacun·e apporte ses connaissances, ses talents ou ses...

--- a/content/events/2026/02/07/festival-parallele.fr.md
+++ b/content/events/2026/02/07/festival-parallele.fr.md
@@ -1,0 +1,28 @@
+---
+title: Festival Parallèle
+date: '2026-02-07T20:00:00+01:00'
+draft: false
+expiryDate: '2026-02-08T00:00:00+01:00'
+name: Festival Parallèle
+eventURL: https://www.lafriche.org/evenements/festival-parallele-16/
+startTime: '20:00'
+description: La 16e édition du festival Parallèle, c’est une quarantaine d’artistes, des spectacles, des expositions, des rencontres et des fêtes.Structure résidente...
+categories:
+- musique
+locations:
+- la-friche
+dates:
+- samedi-07-fevrier
+tags:
+- musique son
+- théâtre
+- danse
+- performance
+- newsletter
+image: /images/events/festival-parallele-f12a3ef1.webp
+sourceId: lafriche:festival-parallele-16
+lastCrawled: '2026-01-27T11:38:37+01:00'
+expired: false
+---
+
+La 16e édition du festival Parallèle, c’est une quarantaine d’artistes, des spectacles, des expositions, des rencontres et des fêtes.Structure résidente...

--- a/content/events/2026/03/25/le-mauvais-oeil-83-cult-pump.fr.md
+++ b/content/events/2026/03/25/le-mauvais-oeil-83-cult-pump.fr.md
@@ -1,0 +1,26 @@
+---
+title: 'Le Mauvais Œil 83 : Cult Pump'
+date: '2026-03-25T20:00:00+01:00'
+draft: false
+expiryDate: '2026-03-26T00:00:00+01:00'
+name: 'Le Mauvais Œil 83 : Cult Pump'
+eventURL: https://www.lafriche.org/evenements/le-mauvais-oeil-83-cult-pump/
+startTime: '20:00'
+description: À la croisée du fanzine anarchique et de la bande dessinée expérimentale, Cult Pump nous plonge dans son univers radical et foisonnant.
+categories:
+- art
+locations:
+- la-friche
+dates:
+- mercredi-25-mars
+tags:
+- exposition
+- événement passé
+- newsletter
+image: /images/events/le-mauvais-oeil-83-cult-pump-d9a01c6d.webp
+sourceId: lafriche:le-mauvais-oeil-83-cult-pump
+lastCrawled: '2026-01-27T11:38:17+01:00'
+expired: false
+---
+
+À la croisée du fanzine anarchique et de la bande dessinée expérimentale, Cult Pump nous plonge dans son univers radical et foisonnant.

--- a/content/events/2026/03/29/expo-pause.fr.md
+++ b/content/events/2026/03/29/expo-pause.fr.md
@@ -1,0 +1,28 @@
+---
+title: Expo-pause
+date: '2026-03-29T20:00:00+02:00'
+draft: false
+expiryDate: '2026-03-30T00:00:00+02:00'
+name: Expo-pause
+eventURL: https://www.lafriche.org/evenements/expo-pause-4/
+startTime: '20:00'
+description: Au 4e étage de la Tour, où se déroule actuellement l’exposition ‘M.A.D (Model Autophagy Disorder)’, les équipes de médiation culturelle ont imaginé un...
+categories:
+- art
+locations:
+- la-friche
+dates:
+- dimanche-29-mars
+tags:
+- exposition
+- rencontre
+- événement passé
+- visite
+- newsletter
+image: /images/events/expo-pause-d5d3f189.webp
+sourceId: lafriche:expo-pause-4
+lastCrawled: '2026-01-27T11:38:42+01:00'
+expired: false
+---
+
+Au 4e étage de la Tour, où se déroule actuellement l’exposition ‘M.A.D (Model Autophagy Disorder)’, les équipes de médiation culturelle ont imaginé un...

--- a/content/events/2026/04/26/au-grand-jour.fr.md
+++ b/content/events/2026/04/26/au-grand-jour.fr.md
@@ -1,0 +1,28 @@
+---
+title: Au grand jour
+date: '2026-04-26T20:00:00+02:00'
+draft: false
+expiryDate: '2026-04-27T00:00:00+02:00'
+name: Au grand jour
+eventURL: https://www.lafriche.org/evenements/au-grand-jour/
+startTime: '20:00'
+description: Le billet d’entrée, même si vous bénéficiez de la gratuité, est indispensable, il donne accès à l’ensemble des expositions de la Tour et du Panorama.
+categories:
+- art
+locations:
+- la-friche
+dates:
+- dimanche-26-avril
+tags:
+- exposition
+- événement passé
+- rencontre
+- littérature édition
+- newsletter
+image: /images/events/au-grand-jour-3a7bf7e9.webp
+sourceId: lafriche:au-grand-jour
+lastCrawled: '2026-01-27T11:38:18+01:00'
+expired: false
+---
+
+Le billet d’entrée, même si vous bénéficiez de la gratuité, est indispensable, il donne accès à l’ensemble des expositions de la Tour et du Panorama.

--- a/crawler/config/sources.yaml
+++ b/crawler/config/sources.yaml
@@ -35,7 +35,7 @@ sources:
       event_list: ".agenda-list"
       event_item: ".event-card"
       name: "h2, h3, .event-title, .title"
-      date: ".date, .event-date, time"
+      date: ".date-date"
       time: ".time, .event-time, .hour"
       location: ".location, .venue"
       description: ".description, .excerpt, p"


### PR DESCRIPTION
## Summary
- Added 19 event content files that were generated by the crawler but never committed to git
- Updated crawler sources.yaml with correct date selector for La Friche
- Root cause: GitHub Actions only deploys tracked files, so untracked content never appeared on production

## Root Cause Analysis
The issue was that event files generated by the crawler were not being committed to git. Since GitHub Actions clones the repository and only has access to tracked files, these events never made it to the production build.

**Local:** 26 events visible (8 tracked + 18 untracked)
**Production:** Only 8 events visible (tracked files only)

## Changes
- Added events from January through April 2026
- Events include: La Friche exhibitions, festivals, concerts, theatre performances
- Fixed date selector in crawler config for La Friche source

## Test plan
- [x] Hugo build completes successfully (129 pages generated)
- [x] Event pages are generated in `public/events/2026/`
- [ ] After merge, verify events appear on https://massalia.events/

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)