### PR TITLE
Simplify events page to show only sorted event list

### DIFF
--- a/content/events/_index.fr.md
+++ b/content/events/_index.fr.md
@@ -10,28 +10,3 @@ cascade:
   showWordCount: false
   showAuthor: false
 ---
-
-Bienvenue sur l'agenda culturel de Marseille. Découvrez les événements de la semaine : spectacles de danse, concerts, pièces de théâtre, expositions et activités communautaires.
-
-## Structure des événements
-
-Les événements sont organisés par date dans une structure `/events/YYYY/MM/DD/`:
-
-```
-/content/events/
-├── _index.fr.md
-├── 2026/
-│   └── 01/
-│       ├── 26/
-│       │   └── vendre-la-meche.fr.md
-│       ├── 27/
-│       │   ├── concert-la-friche.fr.md
-│       │   └── theatre-la-criee.fr.md
-│       └── 29/
-│           └── exposition-la-releve.fr.md
-```
-
-Pour créer un nouvel événement:
-```bash
-hugo new events/2026/01/30/nom-evenement.fr.md --kind events
-```

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -1,22 +1,9 @@
 {{ define "main" }}
 {{/*
-  Events list page - shows all non-expired events
-  This overrides the default Blowfish list template to filter expired events
+  Events list page - shows all non-expired events sorted by date (most recent first)
 */}}
 
 {{ .Scratch.Set "scope" "list" }}
-{{ $enableToc := .Params.showTableOfContents | default (site.Params.list.showTableOfContents | default false) }}
-{{ $showToc := and $enableToc (in .TableOfContents "<ul") }}
-
-{{/* Hero */}}
-{{ if site.Params.list.showHero | default false }}
-  {{ $heroStyle := print "hero/" site.Params.list.heroStyle ".html" }}
-  {{ if templates.Exists ( printf "partials/%s" $heroStyle ) }}
-    {{ partial $heroStyle . }}
-  {{ else }}
-    {{ partial "hero/basic.html" . }}
-  {{ end }}
-{{ end }}
 
 {{/* Header */}}
 <header>
@@ -24,120 +11,19 @@
     {{ partial "breadcrumbs.html" . }}
   {{ end }}
   <h1 class="mt-5 text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Title }}</h1>
-  <div class="mt-1 mb-2 text-base text-neutral-500 dark:text-neutral-400 print:hidden">
-    {{ partial "article-meta/list.html" (dict "context" . "scope" "single") }}
-  </div>
 </header>
-
-{{/* Description (markdown content) */}}
-{{ $tocMargin := cond $showToc "mt-12" "mt-0" }}
-{{ $topClass := cond (hasPrefix site.Params.header.layout "fixed") "lg:top-[140px]" "lg:top-10" }}
-<section class="{{ $tocMargin }} prose flex max-w-full flex-col dark:prose-invert lg:flex-row mb-10">
-  {{ if $showToc }}
-    <div class="order-first lg:ms-auto px-0 lg:order-last lg:ps-8 lg:max-w-2xs">
-      <div class="toc ps-5 print:hidden lg:sticky {{ $topClass }}">
-        {{ partial "toc.html" . }}
-      </div>
-    </div>
-  {{ end }}
-  <div class="min-w-0 min-h-0 max-w-prose w-full">
-    {{ .Content }}
-  </div>
-</section>
 
 {{/* Filter expired events using our custom partial */}}
 {{ $allPages := .Pages }}
 {{ $activeEvents := partial "filter-active-events.html" (dict "pages" $allPages) }}
 
-{{/* Article Grid */}}
+{{/* Events list sorted by date, soonest first */}}
 {{ if gt (len $activeEvents) 0 }}
-  {{ $cardView := .Params.cardView | default (site.Params.list.cardView | default false) }}
-  {{ $cardViewScreenWidth := .Params.cardViewScreenWidth | default (site.Params.list.cardViewScreenWidth | default false) }}
-  {{ $groupByYear := .Params.groupByYear | default (site.Params.list.groupByYear | default false) }}
-  {{ $orderByWeight := .Params.orderByWeight | default (site.Params.list.orderByWeight | default false) }}
-  {{ $groupByYear := and (not $orderByWeight) $groupByYear }}
-
-  {{ if not $cardView }}
-    <section class="space-y-10 w-full">
-      {{ if not $orderByWeight }}
-        {{ range ($activeEvents.GroupByDate "2006") }}
-          {{ if $groupByYear }}
-            <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
-              {{ .Key }}
-            </h2>
-          {{ end }}
-          {{ range .Pages }}
-            {{ partial "article-link/simple.html" . }}
-          {{ end }}
-        {{ end }}
-      {{ else }}
-        {{ range $activeEvents.ByWeight }}
-          {{ partial "article-link/simple.html" . }}
-        {{ end }}
-      {{ end }}
-    </section>
-  {{/* else: is cardView */}}
-  {{ else }}
-    {{ if $groupByYear }}
-      {{ range ($activeEvents.GroupByDate "2006") }}
-        {{ if $cardViewScreenWidth }}
-          <div class="relative w-screen max-w-[1600px] px-[30px] start-[calc(max(-50vw,-800px)+50%)]">
-            <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
-              {{ .Key }}
-            </h2>
-            <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
-              {{ range .Pages }}
-                {{ partial "article-link/card.html" . }}
-              {{ end }}
-            </section>
-          </div>
-        {{ else }}
-          <h2 class="mt-12 mb-3 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
-            {{ .Key }}
-          </h2>
-          <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-            {{ range .Pages }}
-              {{ partial "article-link/card.html" . }}
-            {{ end }}
-          </section>
-        {{ end }}
-      {{ end }}
-
-    {{/* else: not groupByYear */}}
-    {{ else }}
-      {{ if $cardViewScreenWidth }}
-        <div class="relative w-screen max-w-[1600px] px-[30px] start-[calc(max(-50vw,-800px)+50%)]">
-          <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
-            {{ if not $orderByWeight }}
-              {{ range ($activeEvents.GroupByDate "2006") }}
-                {{ range .Pages }}
-                  {{ partial "article-link/card.html" . }}
-                {{ end }}
-              {{ end }}
-            {{ else }}
-              {{ range $activeEvents.ByWeight }}
-                {{ partial "article-link/card.html" . }}
-              {{ end }}
-            {{ end }}
-          </section>
-        </div>
-      {{ else }}
-        <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-          {{ if not $orderByWeight }}
-            {{ range ($activeEvents.GroupByDate "2006") }}
-              {{ range .Pages }}
-                {{ partial "article-link/card.html" . }}
-              {{ end }}
-            {{ end }}
-          {{ else }}
-            {{ range $activeEvents.ByWeight }}
-              {{ partial "article-link/card.html" . }}
-            {{ end }}
-          {{ end }}
-        </section>
-      {{ end }}{{/* End of cardViewScreenWidth */}}
-    {{ end }}{{/* End of groupByYear */}}
-  {{ end }}{{/* End of cardView */}}
+  <section class="mt-6 w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+    {{ range sort $activeEvents ".Date" "asc" }}
+      {{ partial "article-link/card.html" . }}
+    {{ end }}
+  </section>
 {{/* else: no active events */}}
 {{ else }}
   <section class="mt-10 prose dark:prose-invert">


### PR DESCRIPTION
## Summary
- Remove explanation text and directory structure documentation from events index page
- Remove hero section, table of contents, and complex display options from events template
- Show only event cards sorted by date (soonest first)

## Test plan
- [x] Verify events page at /events/ shows only the title and event cards
- [x] Verify events are sorted by date with soonest events at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)