### PR TITLE
Add Le Cepac Silo crawler

### DIFF
--- a/crawler/config/sources.yaml
+++ b/crawler/config/sources.yaml
@@ -146,6 +146,31 @@ sources:
       "Festival": "communaute"
       "Exposition": "art"
 
+  # Le Cepac Silo - Major concert and performance venue in Marseille
+  # 2,050-seat venue in a converted grain silo on the port
+  - name: "Le Cepac Silo"
+    id: "cepacsilo"
+    url: "https://www.cepacsilo-marseille.fr/evenements/"
+    parser: "cepacsilo"
+    enabled: true
+    rate_limit:
+      requests_per_second: 0.5
+      delay_between_pages: 3.0
+    categories_map:
+      "Ballet": "danse"
+      "Comédie musicale": "theatre"
+      "Concert": "musique"
+      "Concert - Rap/Urbain": "musique"
+      "Danse": "danse"
+      "Événement": "communaute"
+      "Festival": "communaute"
+      "Humour": "theatre"
+      "Jeune Public": "theatre"
+      "Magie": "theatre"
+      "One man show": "theatre"
+      "Spectacle": "theatre"
+      "Théâtre": "theatre"
+
 # Default settings applied to all sources unless overridden
 defaults:
   enabled: true

--- a/crawler/src/crawler.py
+++ b/crawler/src/crawler.py
@@ -310,6 +310,8 @@ class BaseCrawler(ABC):
             "opéra de marseille": "opera-de-marseille",
             "opera de marseille": "opera-de-marseille",
             "le silo": "le-cepac-silo-marseille",
+            "cepac silo": "le-cepac-silo-marseille",
+            "le cepac silo": "le-cepac-silo-marseille",
             "espace julien": "espace-julien",
             "le moulin": "le-moulin",
             "mac marseille": "mac-marseille",

--- a/crawler/src/parsers/__init__.py
+++ b/crawler/src/parsers/__init__.py
@@ -2,6 +2,7 @@
 
 from .agendaculturel import AgendaCulturelParser
 from .base import ConfigurableEventParser, ParsedEvent, SelectorConfig
+from .cepacsilo import CepacSiloParser
 from .journalzebuline import JournalZebulineParser
 from .klemenis import KlemenisParser
 from .lafriche import LaFricheParser
@@ -13,6 +14,7 @@ PARSERS = {
     "shotgun": ShotgunParser,
     "agendaculturel": AgendaCulturelParser,
     "journalzebuline": JournalZebulineParser,
+    "cepacsilo": CepacSiloParser,
     "generic": ConfigurableEventParser,
 }
 
@@ -49,6 +51,7 @@ def list_parsers() -> list[str]:
 
 __all__ = [
     "AgendaCulturelParser",
+    "CepacSiloParser",
     "ConfigurableEventParser",
     "JournalZebulineParser",
     "ParsedEvent",

--- a/crawler/src/parsers/cepacsilo.py
+++ b/crawler/src/parsers/cepacsilo.py
@@ -1,0 +1,481 @@
+"""Parser for Le Cepac Silo events (cepacsilo-marseille.fr)."""
+
+import json
+import re
+from datetime import datetime
+from urllib.parse import urljoin
+from zoneinfo import ZoneInfo
+
+from ..crawler import BaseCrawler
+from ..logger import get_logger
+from ..models.event import Event
+from ..utils.parser import HTMLParser
+
+logger = get_logger(__name__)
+
+PARIS_TZ = ZoneInfo("Europe/Paris")
+
+# Maximum number of listing pages to crawl
+MAX_PAGES = 10
+
+
+def _extract_event_urls_from_html(html: str, base_url: str = "") -> list[str]:
+    """
+    Extract event detail page URLs from a listing page.
+
+    Args:
+        html: HTML content of the listing page
+        base_url: Base URL for resolving relative links
+
+    Returns:
+        List of unique event detail URLs
+    """
+    parser = HTMLParser(html, base_url)
+    urls = set()
+
+    # Event detail links follow pattern /evenement/{slug}/
+    for link in parser.select("a[href*='/evenement/']"):
+        href = link.get("href", "")
+        if not href:
+            continue
+
+        # Resolve relative URLs
+        if href.startswith("/"):
+            href = urljoin(base_url, href)
+
+        # Only include event detail pages (singular /evenement/, not /evenements/)
+        if "/evenement/" in href and "/evenements/" not in href:
+            urls.add(href)
+
+    return sorted(urls)
+
+
+def _extract_json_ld(html: str) -> list[dict]:
+    """
+    Extract JSON-LD structured data from HTML.
+
+    Args:
+        html: HTML content
+
+    Returns:
+        List of parsed JSON-LD objects
+    """
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "html.parser")
+    results = []
+
+    for script in soup.find_all("script", type="application/ld+json"):
+        try:
+            data = json.loads(script.string)
+            if isinstance(data, dict):
+                results.append(data)
+            elif isinstance(data, list):
+                results.extend(data)
+        except (json.JSONDecodeError, TypeError):
+            continue
+
+    return results
+
+
+def _parse_event_dates_from_html(html: str) -> list[datetime]:
+    """
+    Extract individual event dates from the HTML listing elements.
+
+    Le Cepac Silo shows multiple dates in list items like:
+    "samedi 14 février 2026 · 18h00"
+
+    Args:
+        html: HTML content of the detail page
+
+    Returns:
+        List of datetime objects for each showtime
+    """
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "html.parser")
+    dates = []
+
+    # French month mapping
+    months = {
+        "janvier": 1,
+        "février": 2,
+        "fevrier": 2,
+        "mars": 3,
+        "avril": 4,
+        "mai": 5,
+        "juin": 6,
+        "juillet": 7,
+        "août": 8,
+        "aout": 8,
+        "septembre": 9,
+        "octobre": 10,
+        "novembre": 11,
+        "décembre": 12,
+        "decembre": 12,
+    }
+
+    # Pattern: "samedi 14 février 2026 · 18h00" or "samedi 14 février 2026 · 18h"
+    date_pattern = re.compile(
+        r"(\d{1,2})\s+(\w+)\s+(\d{4})\s*[·\-]\s*(\d{1,2})h(\d{2})?",
+        re.IGNORECASE,
+    )
+
+    # Search in li elements (primary location for dates)
+    for li in soup.find_all("li"):
+        text = li.get_text().strip()
+        match = date_pattern.search(text)
+        if match:
+            day = int(match.group(1))
+            month_name = match.group(2).lower()
+            year = int(match.group(3))
+            hour = int(match.group(4))
+            minute = int(match.group(5)) if match.group(5) else 0
+
+            month = months.get(month_name)
+            if month:
+                try:
+                    dt = datetime(year, month, day, hour, minute, tzinfo=PARIS_TZ)
+                    dates.append(dt)
+                except ValueError:
+                    continue
+
+    # Fallback: search entire text for date patterns if no li matches
+    if not dates:
+        text = soup.get_text()
+        for match in date_pattern.finditer(text):
+            day = int(match.group(1))
+            month_name = match.group(2).lower()
+            year = int(match.group(3))
+            hour = int(match.group(4))
+            minute = int(match.group(5)) if match.group(5) else 0
+
+            month = months.get(month_name)
+            if month:
+                try:
+                    dt = datetime(year, month, day, hour, minute, tzinfo=PARIS_TZ)
+                    dates.append(dt)
+                except ValueError:
+                    continue
+
+    return dates
+
+
+def _parse_event_from_json_ld(
+    json_ld: dict, event_url: str, category_map: dict
+) -> Event | None:
+    """
+    Parse an Event from JSON-LD structured data.
+
+    Note: Le Cepac Silo JSON-LD has startDate as the first showtime and
+    endDate as the last showtime, so startDate is used for the event date.
+    For multi-date events, we rely on HTML date parsing instead.
+
+    Args:
+        json_ld: JSON-LD Event dict
+        event_url: URL of the event page
+        category_map: Category mapping dict
+
+    Returns:
+        Event object or None if required fields are missing
+    """
+    name = json_ld.get("name", "").strip()
+    if not name:
+        return None
+
+    # Parse start date
+    start_date_str = json_ld.get("startDate", "")
+    if not start_date_str:
+        return None
+
+    start_datetime = _parse_iso_datetime(start_date_str)
+    if not start_datetime:
+        return None
+
+    # Extract description
+    description = json_ld.get("description", "").strip()
+    # The site uses a placeholder description in JSON-LD; ignore it
+    if "Kira and Morrison" in description or "Snickertown" in description:
+        description = ""
+    if len(description) > 160:
+        description = description[:157] + "..."
+
+    # Extract image
+    image = json_ld.get("image", "")
+
+    # Extract category from event type tag on the page
+    category = "communaute"  # Default
+
+    # Generate source ID from URL slug
+    source_id = _generate_source_id(event_url)
+
+    # Location is always Le Cepac Silo
+    locations = ["le-cepac-silo-marseille"]
+
+    # Extract performer as tag
+    tags = []
+    performer = json_ld.get("performer")
+    if performer:
+        if isinstance(performer, dict):
+            perf_name = performer.get("name", "").strip().lower()
+            if perf_name and perf_name != name.lower():
+                tags.append(perf_name)
+        elif isinstance(performer, list):
+            for p in performer:
+                perf_name = p.get("name", "").strip().lower()
+                if perf_name:
+                    tags.append(perf_name)
+
+    return Event(
+        name=name,
+        event_url=event_url,
+        start_datetime=start_datetime,
+        description=description,
+        image=image if image else None,
+        categories=[category],
+        locations=locations,
+        tags=tags[:5],
+        source_id=source_id,
+    )
+
+
+def _parse_iso_datetime(date_str: str) -> datetime | None:
+    """
+    Parse an ISO datetime string to a timezone-aware datetime in Paris TZ.
+
+    Args:
+        date_str: ISO format datetime string
+
+    Returns:
+        datetime in Paris timezone, or None on failure
+    """
+    try:
+        # Handle .000000Z format
+        date_str = date_str.replace(".000000Z", "+00:00").replace("Z", "+00:00")
+        dt = datetime.fromisoformat(date_str)
+        return dt.astimezone(PARIS_TZ)
+    except (ValueError, TypeError):
+        return None
+
+
+def _generate_source_id(url: str) -> str:
+    """Generate a unique source ID from an event URL."""
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    path = parsed.path.strip("/")
+    segments = path.split("/")
+    event_slug = segments[-1] if segments else path
+    return f"cepacsilo:{event_slug}"
+
+
+class CepacSiloParser(BaseCrawler):
+    """
+    Event parser for Le Cepac Silo (cepacsilo-marseille.fr).
+
+    Le Cepac Silo is a 2,050-seat venue in a converted grain silo
+    on the port of Marseille, hosting concerts, comedy, theatre,
+    and dance events.
+
+    This parser:
+    1. Crawls paginated listing pages (/evenements/page/N/)
+    2. Extracts event detail URLs
+    3. Visits each detail page to extract JSON-LD + HTML data
+    4. Creates separate Event objects for each showtime of multi-date events
+    """
+
+    source_name = "Le Cepac Silo"
+
+    def parse_events(self, parser: HTMLParser) -> list[Event]:
+        """
+        Parse events from Le Cepac Silo listing pages.
+
+        Args:
+            parser: HTMLParser with the first listing page content
+
+        Returns:
+            List of Event objects
+        """
+        events = []
+
+        # Collect event URLs from all listing pages
+        all_event_urls = self._collect_all_event_urls(parser)
+
+        if not all_event_urls:
+            logger.warning("No event URLs found on Le Cepac Silo")
+            return events
+
+        logger.info(f"Found {len(all_event_urls)} event URLs on Le Cepac Silo")
+
+        # Visit each detail page
+        for event_url in all_event_urls:
+            try:
+                page_events = self._parse_detail_page(event_url)
+                events.extend(page_events)
+            except Exception as e:
+                logger.warning(f"Failed to parse event from {event_url}: {e}")
+
+        logger.info(
+            f"Extracted {len(events)} events (including multi-date) from Le Cepac Silo"
+        )
+        return events
+
+    def _collect_all_event_urls(self, first_page_parser: HTMLParser) -> list[str]:
+        """
+        Collect event URLs from all listing pages with pagination.
+
+        Args:
+            first_page_parser: HTMLParser with first page content
+
+        Returns:
+            List of unique event detail URLs
+        """
+        all_urls = set()
+
+        # Extract from first page
+        first_page_urls = _extract_event_urls_from_html(
+            str(first_page_parser.soup), self.base_url
+        )
+        all_urls.update(first_page_urls)
+
+        # Check for pagination and fetch subsequent pages
+        for page_num in range(2, MAX_PAGES + 1):
+            page_url = f"{self.base_url.rstrip('/')}/page/{page_num}/"
+            html = self.fetch_page(page_url)
+            if not html:
+                break
+
+            page_urls = _extract_event_urls_from_html(html, self.base_url)
+            if not page_urls:
+                break
+
+            all_urls.update(page_urls)
+            logger.debug(
+                f"Page {page_num}: found {len(page_urls)} events "
+                f"(total: {len(all_urls)})"
+            )
+
+        return sorted(all_urls)
+
+    def _parse_detail_page(self, event_url: str) -> list[Event]:
+        """
+        Fetch and parse an event detail page.
+
+        For events with multiple showtimes, creates a separate Event
+        for each future date.
+
+        Args:
+            event_url: URL of the event detail page
+
+        Returns:
+            List of Event objects (one per showtime)
+        """
+        html = self.fetch_page(event_url)
+        if not html:
+            logger.warning(f"Failed to fetch detail page: {event_url}")
+            return []
+
+        # Extract JSON-LD for base event info
+        json_ld_list = _extract_json_ld(html)
+        event_json_ld = None
+        for item in json_ld_list:
+            if item.get("@type") == "Event":
+                event_json_ld = item
+                break
+
+        if not event_json_ld:
+            logger.debug(f"No Event JSON-LD found on: {event_url}")
+            return []
+
+        # Parse base event from JSON-LD
+        base_event = _parse_event_from_json_ld(
+            event_json_ld, event_url, self.category_map
+        )
+        if not base_event:
+            logger.debug(f"Could not parse base event from JSON-LD: {event_url}")
+            return []
+
+        # Extract category from HTML (more reliable than JSON-LD on this site)
+        category = self._extract_category_from_html(html)
+        if category:
+            base_event.categories = [category]
+
+        # Extract description from HTML if JSON-LD had placeholder
+        if not base_event.description:
+            base_event.description = self._extract_description_from_html(html)
+
+        # Parse all individual showtimes from HTML
+        all_dates = _parse_event_dates_from_html(html)
+
+        if not all_dates:
+            # Use JSON-LD startDate as single event
+            return [base_event]
+
+        # Filter to unique dates and create one event per showtime
+        now = datetime.now(PARIS_TZ)
+        events = []
+        seen_dates = set()
+
+        for dt in all_dates:
+            # Skip past dates
+            if dt < now:
+                continue
+
+            # Deduplicate same datetime
+            dt_key = dt.isoformat()
+            if dt_key in seen_dates:
+                continue
+            seen_dates.add(dt_key)
+
+            # Create event for this showtime
+            event = Event(
+                name=base_event.name,
+                event_url=event_url,
+                start_datetime=dt,
+                description=base_event.description,
+                image=base_event.image,
+                categories=list(base_event.categories),
+                locations=list(base_event.locations),
+                tags=list(base_event.tags),
+                source_id=f"{_generate_source_id(event_url)}:{dt.strftime('%Y%m%d-%H%M')}",
+            )
+            events.append(event)
+
+        # If all dates were in the past, still return the base event
+        # if its JSON-LD date is in the future
+        if not events and base_event.start_datetime >= now:
+            return [base_event]
+
+        return events
+
+    def _extract_category_from_html(self, html: str) -> str:
+        """
+        Extract event category from HTML elements.
+
+        Looks for the .card-event__tag or .term class.
+        """
+        detail_parser = HTMLParser(html, self.base_url)
+
+        # Try specific category selectors used by Cepac Silo
+        for selector in [".card-event__tag", ".term", ".content-header .term"]:
+            elem = detail_parser.select_one(selector)
+            if elem:
+                category_text = elem.get_text().strip()
+                if category_text:
+                    return self.map_category(category_text)
+
+        return ""
+
+    def _extract_description_from_html(self, html: str) -> str:
+        """Extract event description from HTML content."""
+        detail_parser = HTMLParser(html, self.base_url)
+
+        # Try selectors commonly used on the Cepac Silo site
+        for selector in [".about p", ".about", ".description", "article p"]:
+            elem = detail_parser.select_one(selector)
+            if elem:
+                text = elem.get_text().strip()
+                if len(text) > 20:
+                    return HTMLParser.truncate(text, 160)
+
+        return ""

--- a/crawler/tests/test_cepacsilo_parser.py
+++ b/crawler/tests/test_cepacsilo_parser.py
@@ -1,0 +1,744 @@
+"""Tests for the Le Cepac Silo parser."""
+
+import json
+from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src.models.event import Event
+from src.parsers.cepacsilo import (
+    CepacSiloParser,
+    _extract_event_urls_from_html,
+    _extract_json_ld,
+    _generate_source_id,
+    _parse_event_dates_from_html,
+    _parse_event_from_json_ld,
+    _parse_iso_datetime,
+)
+from src.utils.parser import HTMLParser
+
+PARIS_TZ = ZoneInfo("Europe/Paris")
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def sample_listing_html():
+    """Sample Le Cepac Silo listing page with event cards."""
+    return """
+    <html>
+    <body>
+        <div class="bl-evc__list">
+            <a href="/evenement/haroun/">
+                <div class="card-event" data-title="HAROUN" data-category="One man show">
+                    <img src="/wp-content/uploads/haroun.jpg" alt="HAROUN">
+                    <div class="card-event__content">
+                        <span class="card-event__tag">One man show</span>
+                        <h3 class="card-event__title">HAROUN</h3>
+                    </div>
+                </div>
+            </a>
+            <a href="/evenement/djal-2/">
+                <div class="card-event" data-title="D'JAL" data-category="One man show">
+                    <img src="/wp-content/uploads/djal.jpg" alt="D'JAL">
+                    <div class="card-event__content">
+                        <span class="card-event__tag">One man show</span>
+                        <h3 class="card-event__title">D'JAL</h3>
+                    </div>
+                </div>
+            </a>
+            <a href="/evenement/ballet-national/">
+                <div class="card-event" data-title="Ballet National" data-category="Ballet">
+                    <img src="/wp-content/uploads/ballet.jpg" alt="Ballet National">
+                    <div class="card-event__content">
+                        <span class="card-event__tag">Ballet</span>
+                        <h3 class="card-event__title">Ballet National</h3>
+                    </div>
+                </div>
+            </a>
+            <!-- Non-event link -->
+            <a href="/evenements/page/2/">Page 2</a>
+        </div>
+        <nav>
+            <a href="https://www.cepacsilo-marseille.fr/evenements/page/2/">2</a>
+            <a href="https://www.cepacsilo-marseille.fr/evenements/page/3/">3</a>
+        </nav>
+    </body>
+    </html>
+    """
+
+
+@pytest.fixture
+def sample_detail_html():
+    """Sample event detail page with JSON-LD and multiple dates."""
+    json_ld = json.dumps(
+        {
+            "@context": "https://schema.org",
+            "@type": "Event",
+            "name": "HAROUN",
+            "startDate": "2026-02-14T18:00:00.000000Z",
+            "endDate": "2027-02-06T21:00:00.000000Z",
+            "eventStatus": "https://schema.org/EventScheduled",
+            "location": {
+                "@type": "Place",
+                "name": "CEPAC SILO",
+                "address": {
+                    "@type": "PostalAddress",
+                    "streetAddress": "35 quai du Lazaret",
+                    "addressLocality": "Marseille",
+                    "postalCode": "13002",
+                    "addressCountry": "FR",
+                },
+            },
+            "image": "https://www.cepacsilo-marseille.fr/wp-content/uploads/haroun.jpg",
+            "description": "The Adventures of Kira and Morrison is coming to Snickertown in a can't miss performance.",
+            "performer": {"@type": "Person", "name": "HAROUN"},
+        }
+    )
+    return f"""
+    <html>
+    <head>
+        <script type="application/ld+json">{json_ld}</script>
+    </head>
+    <body>
+        <div class="content-header">
+            <span class="term">One man show</span>
+        </div>
+        <h1 class="bl-he__title">HAROUN</h1>
+        <h2>Bonjour quand même</h2>
+        <div class="about">
+            <p>NOUVEAU SPECTACLE - Haroun revient avec un spectacle hilarant et profond.</p>
+        </div>
+        <ul>
+            <li>samedi 14 février 2026 · 18h00</li>
+            <li>samedi 14 février 2026 · 21h00</li>
+            <li>samedi 06 février 2027 · 18h00</li>
+            <li>samedi 06 février 2027 · 21h00</li>
+        </ul>
+    </body>
+    </html>
+    """
+
+
+@pytest.fixture
+def sample_single_date_detail():
+    """Sample event detail page with a single date."""
+    json_ld = json.dumps(
+        {
+            "@context": "https://schema.org",
+            "@type": "Event",
+            "name": "D'JAL",
+            "startDate": "2026-02-06T20:30:00.000000Z",
+            "endDate": "2026-02-06T20:30:00.000000Z",
+            "eventStatus": "https://schema.org/EventScheduled",
+            "location": {
+                "@type": "Place",
+                "name": "CEPAC SILO",
+                "address": {
+                    "@type": "PostalAddress",
+                    "streetAddress": "35 quai du Lazaret",
+                    "addressLocality": "Marseille",
+                    "postalCode": "13002",
+                    "addressCountry": "FR",
+                },
+            },
+            "image": "https://www.cepacsilo-marseille.fr/wp-content/uploads/djal.jpg",
+            "description": "D'jal revient avec un nouveau spectacle.",
+            "performer": {"@type": "Person", "name": "D'JAL"},
+        }
+    )
+    return f"""
+    <html>
+    <head>
+        <script type="application/ld+json">{json_ld}</script>
+    </head>
+    <body>
+        <div class="content-header">
+            <span class="term">One man show</span>
+        </div>
+        <h1 class="bl-he__title">D'JAL</h1>
+        <div class="about">
+            <p>D'jal revient avec un nouveau spectacle mêlant personnages dingues et situations folles!</p>
+        </div>
+        <ul>
+            <li>vendredi 06 février 2026 · 20h30</li>
+        </ul>
+    </body>
+    </html>
+    """
+
+
+@pytest.fixture
+def sample_json_ld_event():
+    """A complete Event JSON-LD object from Cepac Silo."""
+    return {
+        "@context": "https://schema.org",
+        "@type": "Event",
+        "name": "DJAL",
+        "startDate": "2026-02-06T20:30:00.000000Z",
+        "endDate": "2026-02-06T20:30:00.000000Z",
+        "eventStatus": "https://schema.org/EventScheduled",
+        "location": {
+            "@type": "Place",
+            "name": "CEPAC SILO",
+            "address": {
+                "@type": "PostalAddress",
+                "streetAddress": "35 quai du Lazaret",
+                "addressLocality": "Marseille",
+                "postalCode": "13002",
+                "addressCountry": "FR",
+            },
+        },
+        "image": "https://www.cepacsilo-marseille.fr/wp-content/uploads/djal.jpg",
+        "description": "D'jal revient pour sa troisième édition.",
+        "performer": {"@type": "Person", "name": "D'JAL"},
+    }
+
+
+@pytest.fixture
+def category_map():
+    """Standard category mapping from sources.yaml."""
+    return {
+        "Ballet": "danse",
+        "Comédie musicale": "theatre",
+        "Concert": "musique",
+        "Concert - Rap/Urbain": "musique",
+        "Danse": "danse",
+        "Événement": "communaute",
+        "Festival": "communaute",
+        "Humour": "theatre",
+        "Jeune Public": "theatre",
+        "Magie": "theatre",
+        "One man show": "theatre",
+        "Spectacle": "theatre",
+        "Théâtre": "theatre",
+    }
+
+
+# ── Test _extract_event_urls_from_html ────────────────────────────
+
+
+class TestExtractEventUrls:
+    """Tests for extracting event URLs from listing page HTML."""
+
+    def test_extracts_event_urls(self, sample_listing_html):
+        urls = _extract_event_urls_from_html(
+            sample_listing_html,
+            "https://www.cepacsilo-marseille.fr",
+        )
+        assert len(urls) == 3
+        assert any("haroun" in u for u in urls)
+        assert any("djal-2" in u for u in urls)
+        assert any("ballet-national" in u for u in urls)
+
+    def test_excludes_listing_page_links(self, sample_listing_html):
+        urls = _extract_event_urls_from_html(
+            sample_listing_html,
+            "https://www.cepacsilo-marseille.fr",
+        )
+        assert not any("/evenements/" in u for u in urls)
+
+    def test_resolves_relative_urls(self, sample_listing_html):
+        urls = _extract_event_urls_from_html(
+            sample_listing_html,
+            "https://www.cepacsilo-marseille.fr",
+        )
+        for url in urls:
+            assert url.startswith("https://")
+
+    def test_handles_empty_html(self):
+        urls = _extract_event_urls_from_html("<html><body></body></html>")
+        assert urls == []
+
+    def test_deduplicates_urls(self):
+        html = """
+        <html><body>
+            <a href="/evenement/test/">Link 1</a>
+            <a href="/evenement/test/">Link 2</a>
+        </body></html>
+        """
+        urls = _extract_event_urls_from_html(html, "https://www.cepacsilo-marseille.fr")
+        assert len(urls) == 1
+
+    def test_handles_absolute_urls(self):
+        html = """
+        <html><body>
+            <a href="https://www.cepacsilo-marseille.fr/evenement/test-event/">Test</a>
+        </body></html>
+        """
+        urls = _extract_event_urls_from_html(html)
+        assert len(urls) == 1
+        assert urls[0] == "https://www.cepacsilo-marseille.fr/evenement/test-event/"
+
+
+# ── Test _extract_json_ld ─────────────────────────────────────────
+
+
+class TestExtractJsonLd:
+    """Tests for extracting JSON-LD data from HTML."""
+
+    def test_extracts_json_ld(self, sample_detail_html):
+        results = _extract_json_ld(sample_detail_html)
+        assert len(results) == 1
+        assert results[0]["@type"] == "Event"
+
+    def test_handles_no_json_ld(self):
+        html = "<html><head></head><body></body></html>"
+        results = _extract_json_ld(html)
+        assert results == []
+
+    def test_handles_invalid_json(self):
+        html = '<html><head><script type="application/ld+json">{invalid</script></head></html>'
+        results = _extract_json_ld(html)
+        assert results == []
+
+    def test_handles_multiple_scripts(self):
+        data1 = json.dumps({"@type": "WebSite", "name": "Test"})
+        data2 = json.dumps({"@type": "Event", "name": "Concert"})
+        html = f"""
+        <html><head>
+            <script type="application/ld+json">{data1}</script>
+            <script type="application/ld+json">{data2}</script>
+        </head></html>
+        """
+        results = _extract_json_ld(html)
+        assert len(results) == 2
+
+
+# ── Test _parse_event_dates_from_html ─────────────────────────────
+
+
+class TestParseEventDatesFromHtml:
+    """Tests for extracting individual showtimes from HTML."""
+
+    def test_parses_multiple_dates(self, sample_detail_html):
+        dates = _parse_event_dates_from_html(sample_detail_html)
+        assert len(dates) == 4
+
+    def test_parses_date_components(self, sample_detail_html):
+        dates = _parse_event_dates_from_html(sample_detail_html)
+        # First date: samedi 14 février 2026 · 18h00
+        assert dates[0].year == 2026
+        assert dates[0].month == 2
+        assert dates[0].day == 14
+        assert dates[0].hour == 18
+        assert dates[0].minute == 0
+        assert dates[0].tzinfo == PARIS_TZ
+
+    def test_parses_different_times(self, sample_detail_html):
+        dates = _parse_event_dates_from_html(sample_detail_html)
+        # Second date: samedi 14 février 2026 · 21h00
+        assert dates[1].hour == 21
+        assert dates[1].minute == 0
+
+    def test_parses_single_date(self, sample_single_date_detail):
+        dates = _parse_event_dates_from_html(sample_single_date_detail)
+        assert len(dates) == 1
+        assert dates[0].hour == 20
+        assert dates[0].minute == 30
+
+    def test_handles_no_dates(self):
+        html = "<html><body><p>No dates here</p></body></html>"
+        dates = _parse_event_dates_from_html(html)
+        assert dates == []
+
+    def test_handles_various_french_months(self):
+        months_data = [
+            ("janvier", 1),
+            ("mars", 3),
+            ("septembre", 9),
+            ("décembre", 12),
+        ]
+        for month_name, month_num in months_data:
+            html = f"<html><body><li>samedi 15 {month_name} 2026 · 20h30</li></body></html>"
+            dates = _parse_event_dates_from_html(html)
+            assert len(dates) == 1, f"Failed for {month_name}"
+            assert dates[0].month == month_num, f"Wrong month for {month_name}"
+
+    def test_handles_time_without_minutes(self):
+        html = "<html><body><li>samedi 15 mars 2026 · 20h</li></body></html>"
+        dates = _parse_event_dates_from_html(html)
+        # The pattern requires at least "20h" which our regex handles (minutes optional)
+        # This should match with minute=0 via the (\d{2})? group
+        assert len(dates) == 1
+        assert dates[0].hour == 20
+        assert dates[0].minute == 0
+
+
+# ── Test _parse_event_from_json_ld ────────────────────────────────
+
+
+class TestParseEventFromJsonLd:
+    """Tests for converting JSON-LD to Event objects."""
+
+    def test_parses_basic_event(self, sample_json_ld_event, category_map):
+        event = _parse_event_from_json_ld(
+            sample_json_ld_event,
+            "https://www.cepacsilo-marseille.fr/evenement/djal-2/",
+            category_map,
+        )
+        assert event is not None
+        assert event.name == "DJAL"
+        assert event.event_url == "https://www.cepacsilo-marseille.fr/evenement/djal-2/"
+
+    def test_parses_start_datetime(self, sample_json_ld_event, category_map):
+        event = _parse_event_from_json_ld(
+            sample_json_ld_event,
+            "https://www.cepacsilo-marseille.fr/evenement/djal-2/",
+            category_map,
+        )
+        # 2026-02-06T20:30:00Z = 2026-02-06T21:30:00+01:00 in Paris
+        assert event.start_datetime.year == 2026
+        assert event.start_datetime.month == 2
+        assert event.start_datetime.day == 6
+        assert event.start_datetime.hour == 21  # UTC+1
+
+    def test_ignores_placeholder_description(self, category_map):
+        json_ld = {
+            "@type": "Event",
+            "name": "Test",
+            "startDate": "2026-02-06T20:30:00.000000Z",
+            "description": "The Adventures of Kira and Morrison is coming to Snickertown in a can't miss performance.",
+        }
+        event = _parse_event_from_json_ld(
+            json_ld,
+            "https://www.cepacsilo-marseille.fr/evenement/test/",
+            category_map,
+        )
+        assert event.description == ""
+
+    def test_keeps_real_description(self, category_map):
+        json_ld = {
+            "@type": "Event",
+            "name": "Test",
+            "startDate": "2026-02-06T20:30:00.000000Z",
+            "description": "Un spectacle magnifique à ne pas rater.",
+        }
+        event = _parse_event_from_json_ld(
+            json_ld,
+            "https://www.cepacsilo-marseille.fr/evenement/test/",
+            category_map,
+        )
+        assert event.description == "Un spectacle magnifique à ne pas rater."
+
+    def test_parses_image(self, sample_json_ld_event, category_map):
+        event = _parse_event_from_json_ld(
+            sample_json_ld_event,
+            "https://www.cepacsilo-marseille.fr/evenement/djal-2/",
+            category_map,
+        )
+        assert (
+            event.image
+            == "https://www.cepacsilo-marseille.fr/wp-content/uploads/djal.jpg"
+        )
+
+    def test_location_is_cepac_silo(self, sample_json_ld_event, category_map):
+        event = _parse_event_from_json_ld(
+            sample_json_ld_event,
+            "https://www.cepacsilo-marseille.fr/evenement/djal-2/",
+            category_map,
+        )
+        assert "le-cepac-silo-marseille" in event.locations
+
+    def test_extracts_performer_as_tag(self, sample_json_ld_event, category_map):
+        event = _parse_event_from_json_ld(
+            sample_json_ld_event,
+            "https://www.cepacsilo-marseille.fr/evenement/djal-2/",
+            category_map,
+        )
+        assert "d'jal" in event.tags
+
+    def test_returns_none_for_missing_name(self, category_map):
+        json_ld = {"@type": "Event", "startDate": "2026-02-06T20:30:00.000000Z"}
+        event = _parse_event_from_json_ld(
+            json_ld,
+            "https://www.cepacsilo-marseille.fr/evenement/test/",
+            category_map,
+        )
+        assert event is None
+
+    def test_returns_none_for_missing_date(self, category_map):
+        json_ld = {"@type": "Event", "name": "Test Event"}
+        event = _parse_event_from_json_ld(
+            json_ld,
+            "https://www.cepacsilo-marseille.fr/evenement/test/",
+            category_map,
+        )
+        assert event is None
+
+    def test_truncates_long_description(self, category_map):
+        json_ld = {
+            "@type": "Event",
+            "name": "Test",
+            "startDate": "2026-02-06T20:30:00.000000Z",
+            "description": "A" * 200,
+        }
+        event = _parse_event_from_json_ld(
+            json_ld,
+            "https://www.cepacsilo-marseille.fr/evenement/test/",
+            category_map,
+        )
+        assert len(event.description) <= 160
+
+    def test_handles_no_image(self, category_map):
+        json_ld = {
+            "@type": "Event",
+            "name": "Test",
+            "startDate": "2026-02-06T20:30:00.000000Z",
+        }
+        event = _parse_event_from_json_ld(
+            json_ld,
+            "https://www.cepacsilo-marseille.fr/evenement/test/",
+            category_map,
+        )
+        assert event.image is None
+
+    def test_handles_multiple_performers(self, category_map):
+        json_ld = {
+            "@type": "Event",
+            "name": "Festival",
+            "startDate": "2026-02-06T20:30:00.000000Z",
+            "performer": [
+                {"@type": "Person", "name": "Artist A"},
+                {"@type": "Person", "name": "Artist B"},
+            ],
+        }
+        event = _parse_event_from_json_ld(
+            json_ld,
+            "https://www.cepacsilo-marseille.fr/evenement/festival/",
+            category_map,
+        )
+        assert "artist a" in event.tags
+        assert "artist b" in event.tags
+
+
+# ── Test _parse_iso_datetime ──────────────────────────────────────
+
+
+class TestParseIsoDatetime:
+    """Tests for ISO datetime parsing."""
+
+    def test_parses_z_format(self):
+        dt = _parse_iso_datetime("2026-02-06T20:30:00.000000Z")
+        assert dt is not None
+        assert dt.year == 2026
+        assert dt.tzinfo == PARIS_TZ
+
+    def test_parses_offset_format(self):
+        dt = _parse_iso_datetime("2026-02-06T20:30:00+01:00")
+        assert dt is not None
+        assert dt.hour == 20
+
+    def test_returns_none_for_invalid(self):
+        dt = _parse_iso_datetime("not-a-date")
+        assert dt is None
+
+    def test_returns_none_for_empty(self):
+        dt = _parse_iso_datetime("")
+        assert dt is None
+
+
+# ── Test _generate_source_id ──────────────────────────────────────
+
+
+class TestGenerateSourceId:
+    """Tests for source ID generation."""
+
+    def test_generates_from_url(self):
+        sid = _generate_source_id(
+            "https://www.cepacsilo-marseille.fr/evenement/haroun/"
+        )
+        assert sid == "cepacsilo:haroun"
+
+    def test_generates_from_url_with_suffix(self):
+        sid = _generate_source_id(
+            "https://www.cepacsilo-marseille.fr/evenement/djal-2/"
+        )
+        assert sid == "cepacsilo:djal-2"
+
+
+# ── Test CepacSiloParser integration ─────────────────────────────
+
+
+class TestCepacSiloParserIntegration:
+    """Integration tests for CepacSiloParser with mocked HTTP."""
+
+    @pytest.fixture
+    def mock_config(self, category_map):
+        return {
+            "name": "Le Cepac Silo",
+            "id": "cepacsilo",
+            "url": "https://www.cepacsilo-marseille.fr/evenements/",
+            "parser": "cepacsilo",
+            "rate_limit": {"delay_between_pages": 0.0},
+            "category_map": category_map,
+        }
+
+    @pytest.fixture
+    def parser(self, mock_config):
+        http_client = MagicMock()
+        image_downloader = MagicMock()
+        markdown_generator = MagicMock()
+        return CepacSiloParser(
+            config=mock_config,
+            http_client=http_client,
+            image_downloader=image_downloader,
+            markdown_generator=markdown_generator,
+        )
+
+    def test_source_name(self, parser):
+        assert parser.source_name == "Le Cepac Silo"
+
+    def test_parse_events_with_multi_date_event(
+        self, parser, sample_listing_html, sample_detail_html
+    ):
+        """Test that multi-date events produce multiple Event objects."""
+        # Mock fetch_page: page 2 returns empty (stop pagination),
+        # then detail pages
+        parser.http_client.get_text.side_effect = [
+            "",  # Page 2 (empty, stops pagination)
+            sample_detail_html,  # Detail: haroun
+            sample_detail_html,  # Detail: djal-2
+            sample_detail_html,  # Detail: ballet-national
+        ]
+
+        html_parser = HTMLParser(
+            sample_listing_html,
+            "https://www.cepacsilo-marseille.fr/evenements/",
+        )
+        events = parser.parse_events(html_parser)
+
+        # Each detail page has 4 dates, but past dates are filtered out
+        # All dates are in the future (2026-2027) so we expect events
+        assert len(events) > 0
+        assert all(isinstance(e, Event) for e in events)
+
+    def test_parse_events_with_single_date(self, parser, sample_single_date_detail):
+        """Test single-date event."""
+        listing_html = """
+        <html><body>
+            <a href="/evenement/djal-2/">D'JAL</a>
+        </body></html>
+        """
+        parser.http_client.get_text.side_effect = [
+            "",  # Page 2 (empty)
+            sample_single_date_detail,  # Detail page
+        ]
+
+        html_parser = HTMLParser(
+            listing_html,
+            "https://www.cepacsilo-marseille.fr/evenements/",
+        )
+        events = parser.parse_events(html_parser)
+
+        assert len(events) == 1
+        assert events[0].name == "D'JAL"
+        assert events[0].categories == ["theatre"]
+
+    def test_parse_events_empty_listing(self, parser):
+        """Test graceful handling of empty listing page."""
+        # Mock fetch_page to return empty for pagination attempts
+        parser.http_client.get_text.return_value = ""
+
+        html_parser = HTMLParser(
+            "<html><body></body></html>",
+            "https://www.cepacsilo-marseille.fr/evenements/",
+        )
+        events = parser.parse_events(html_parser)
+        assert events == []
+
+    def test_handles_detail_page_failure(self, parser):
+        """Test graceful handling when detail page fails to load."""
+        listing_html = """
+        <html><body>
+            <a href="/evenement/test/">Test</a>
+        </body></html>
+        """
+        parser.http_client.get_text.side_effect = [
+            "",  # Page 2 (empty)
+            "",  # Detail page fails
+        ]
+
+        html_parser = HTMLParser(
+            listing_html,
+            "https://www.cepacsilo-marseille.fr/evenements/",
+        )
+        events = parser.parse_events(html_parser)
+        assert events == []
+
+    def test_handles_detail_page_without_json_ld(self, parser):
+        """Test handling of detail page without JSON-LD."""
+        listing_html = """
+        <html><body>
+            <a href="/evenement/test/">Test</a>
+        </body></html>
+        """
+        detail_html = """
+        <html>
+        <head></head>
+        <body><h1>Test Event</h1></body>
+        </html>
+        """
+        parser.http_client.get_text.side_effect = [
+            "",  # Page 2 (empty)
+            detail_html,  # Detail without JSON-LD
+        ]
+
+        html_parser = HTMLParser(
+            listing_html,
+            "https://www.cepacsilo-marseille.fr/evenements/",
+        )
+        events = parser.parse_events(html_parser)
+        assert events == []
+
+    def test_extracts_category_from_html(self, parser):
+        """Test category extraction from .term element."""
+        html = """
+        <html><body>
+            <div class="content-header">
+                <span class="term">Concert</span>
+            </div>
+        </body></html>
+        """
+        category = parser._extract_category_from_html(html)
+        assert category == "musique"
+
+    def test_extracts_description_from_html(self, parser):
+        """Test description extraction from .about element."""
+        html = """
+        <html><body>
+            <div class="about">
+                <p>Un spectacle incroyable avec des artistes exceptionnels dans un cadre unique.</p>
+            </div>
+        </body></html>
+        """
+        description = parser._extract_description_from_html(html)
+        assert "spectacle incroyable" in description
+
+    def test_source_id_includes_datetime_for_multi_date(
+        self, parser, sample_detail_html
+    ):
+        """Test that multi-date events get datetime-suffixed source IDs."""
+        listing_html = """
+        <html><body>
+            <a href="/evenement/haroun/">HAROUN</a>
+        </body></html>
+        """
+        parser.http_client.get_text.side_effect = [
+            "",  # Page 2 (empty)
+            sample_detail_html,
+        ]
+
+        html_parser = HTMLParser(
+            listing_html,
+            "https://www.cepacsilo-marseille.fr/evenements/",
+        )
+        events = parser.parse_events(html_parser)
+
+        # Each event should have a unique source_id with datetime suffix
+        source_ids = [e.source_id for e in events]
+        assert len(source_ids) == len(set(source_ids)), "Source IDs should be unique"
+        for sid in source_ids:
+            assert sid.startswith("cepacsilo:haroun:")


### PR DESCRIPTION
## Summary
- Adds Le Cepac Silo (cepacsilo-marseille.fr) as a new event source with dedicated parser
- Crawls paginated listing pages, extracts JSON-LD structured data from detail pages
- Handles multi-date events by creating separate Event objects per showtime
- Maps 13 event categories (Ballet, Concert, Humour, Spectacle, etc.) to the standard taxonomy
- Includes 44 unit and integration tests with full coverage of parsing, date extraction, and edge cases

## Changes
- **`crawler/config/sources.yaml`** - New source configuration with rate limits and category mappings
- **`crawler/src/parsers/cepacsilo.py`** - New parser: listing pagination, JSON-LD parsing, multi-date handling, HTML fallback for description/category
- **`crawler/src/parsers/__init__.py`** - Register CepacSiloParser in parser registry
- **`crawler/src/crawler.py`** - Add "cepac silo" / "le cepac silo" location aliases
- **`crawler/tests/test_cepacsilo_parser.py`** - 44 tests covering URL extraction, JSON-LD parsing, date parsing, integration

## Test plan
- [x] All 44 new tests pass (`pytest tests/test_cepacsilo_parser.py`)
- [x] Full test suite passes (605 passed, 9 pre-existing failures in test_selection.py)
- [x] Ruff linting and formatting checks pass
- [ ] Run live crawl: `python crawl.py run --source cepacsilo`
- [ ] Verify generated event markdown files
- [ ] Verify Hugo build succeeds with new events

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)