### PR TITLE
Consolidate French date/time parsing into shared module

### DIFF
--- a/crawler/src/parsers/agendaculturel.py
+++ b/crawler/src/parsers/agendaculturel.py
@@ -13,16 +13,14 @@ import re
 import time
 from datetime import datetime
 from urllib.parse import urlparse
-from zoneinfo import ZoneInfo
 
 from ..crawler import BaseCrawler
 from ..logger import get_logger
 from ..models.event import Event
+from ..utils.french_date import PARIS_TZ
 from ..utils.parser import HTMLParser
 
 logger = get_logger(__name__)
-
-PARIS_TZ = ZoneInfo("Europe/Paris")
 
 # Maximum number of events to process per crawl
 MAX_EVENTS = 60

--- a/crawler/src/parsers/base.py
+++ b/crawler/src/parsers/base.py
@@ -3,19 +3,16 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING
-from zoneinfo import ZoneInfo
 
 from ..logger import get_logger
 from ..models.event import Event
+from ..utils.french_date import PARIS_TZ
 from ..utils.parser import HTMLParser
 
 if TYPE_CHECKING:
     from bs4 import Tag
 
 logger = get_logger(__name__)
-
-# Paris timezone for event dates
-PARIS_TZ = ZoneInfo("Europe/Paris")
 
 
 @dataclass

--- a/crawler/src/parsers/cepacsilo.py
+++ b/crawler/src/parsers/cepacsilo.py
@@ -4,16 +4,14 @@ import json
 import re
 from datetime import datetime
 from urllib.parse import urljoin
-from zoneinfo import ZoneInfo
 
 from ..crawler import BaseCrawler
 from ..logger import get_logger
 from ..models.event import Event
+from ..utils.french_date import PARIS_TZ
 from ..utils.parser import HTMLParser
 
 logger = get_logger(__name__)
-
-PARIS_TZ = ZoneInfo("Europe/Paris")
 
 # Maximum number of listing pages to crawl
 MAX_PAGES = 10

--- a/crawler/src/parsers/journalzebuline.py
+++ b/crawler/src/parsers/journalzebuline.py
@@ -24,16 +24,14 @@ import json
 import re
 import time
 from datetime import datetime
-from zoneinfo import ZoneInfo
 
 from ..crawler import BaseCrawler
 from ..logger import get_logger
 from ..models.event import Event
+from ..utils.french_date import FRENCH_MONTHS, PARIS_TZ
 from ..utils.parser import HTMLParser
 
 logger = get_logger(__name__)
-
-PARIS_TZ = ZoneInfo("Europe/Paris")
 
 # WordPress REST API pagination - 100 is the WP maximum per page
 WP_PER_PAGE = 100
@@ -54,25 +52,6 @@ WP_CATEGORY_MAP = {
     5659: "theatre",  # Cirque
     2881: "theatre",  # Critiques (parent)
     2883: "theatre",  # On y était
-}
-
-# French month names for date parsing
-FRENCH_MONTHS = {
-    "janvier": 1,
-    "février": 2,
-    "fevrier": 2,
-    "mars": 3,
-    "avril": 4,
-    "mai": 5,
-    "juin": 6,
-    "juillet": 7,
-    "août": 8,
-    "aout": 8,
-    "septembre": 9,
-    "octobre": 10,
-    "novembre": 11,
-    "décembre": 12,
-    "decembre": 12,
 }
 
 # Cities in the Marseille area (for geographic filtering)

--- a/crawler/src/parsers/klemenis.py
+++ b/crawler/src/parsers/klemenis.py
@@ -2,17 +2,14 @@
 
 import re
 from datetime import datetime
-from zoneinfo import ZoneInfo
 
 from ..crawler import BaseCrawler
 from ..logger import get_logger
 from ..models.event import Event
+from ..utils.french_date import FRENCH_MONTHS, PARIS_TZ
 from ..utils.parser import HTMLParser
 
 logger = get_logger(__name__)
-
-# Paris timezone for event dates
-PARIS_TZ = ZoneInfo("Europe/Paris")
 
 
 class KlemenisParser(BaseCrawler):
@@ -222,25 +219,6 @@ class KlemenisParser(BaseCrawler):
 
         text_lower = text.lower()
 
-        # French month names mapping
-        months = {
-            "janvier": 1,
-            "février": 2,
-            "fevrier": 2,
-            "mars": 3,
-            "avril": 4,
-            "mai": 5,
-            "juin": 6,
-            "juillet": 7,
-            "août": 8,
-            "aout": 8,
-            "septembre": 9,
-            "octobre": 10,
-            "novembre": 11,
-            "décembre": 12,
-            "decembre": 12,
-        }
-
         # Pattern for single date with optional time: "30 janvier 2026 à 19h30"
         single_date_pattern = (
             r"(\d{1,2})\s+(\w+)\s+(\d{4})(?:\s+[àa]\s*(\d{1,2})h(\d{2})?)?"
@@ -254,7 +232,7 @@ class KlemenisParser(BaseCrawler):
             hour = int(match.group(4)) if match.group(4) else 20
             minute = int(match.group(5)) if match.group(5) else 0
 
-            month = months.get(month_name)
+            month = FRENCH_MONTHS.get(month_name)
             if month:
                 try:
                     return datetime(year, month, day, hour, minute, tzinfo=PARIS_TZ)
@@ -270,7 +248,7 @@ class KlemenisParser(BaseCrawler):
             month_name = match.group(2)
             year = int(match.group(3))
 
-            month = months.get(month_name)
+            month = FRENCH_MONTHS.get(month_name)
             if month:
                 try:
                     return datetime(year, month, day, 20, 0, tzinfo=PARIS_TZ)

--- a/crawler/src/parsers/lacriee.py
+++ b/crawler/src/parsers/lacriee.py
@@ -3,35 +3,14 @@
 import re
 from datetime import datetime
 from urllib.parse import urljoin
-from zoneinfo import ZoneInfo
 
 from ..crawler import BaseCrawler
 from ..logger import get_logger
 from ..models.event import Event
+from ..utils.french_date import FRENCH_MONTHS, PARIS_TZ
 from ..utils.parser import HTMLParser
 
 logger = get_logger(__name__)
-
-PARIS_TZ = ZoneInfo("Europe/Paris")
-
-# French month name mapping
-FRENCH_MONTHS = {
-    "janvier": 1,
-    "février": 2,
-    "fevrier": 2,
-    "mars": 3,
-    "avril": 4,
-    "mai": 5,
-    "juin": 6,
-    "juillet": 7,
-    "août": 8,
-    "aout": 8,
-    "septembre": 9,
-    "octobre": 10,
-    "novembre": 11,
-    "décembre": 12,
-    "decembre": 12,
-}
 
 
 def _extract_event_urls_from_html(html: str, base_url: str = "") -> list[str]:

--- a/crawler/src/parsers/lafriche.py
+++ b/crawler/src/parsers/lafriche.py
@@ -2,18 +2,15 @@
 
 import re
 from datetime import datetime
-from zoneinfo import ZoneInfo
 
 from ..crawler import BaseCrawler
 from ..logger import get_logger
 from ..models.event import Event
+from ..utils.french_date import FRENCH_MONTHS, PARIS_TZ
 from ..utils.parser import HTMLParser
 from .base import ConfigurableEventParser
 
 logger = get_logger(__name__)
-
-# Paris timezone for event dates
-PARIS_TZ = ZoneInfo("Europe/Paris")
 
 
 class LaFricheParser(BaseCrawler):
@@ -217,25 +214,6 @@ class LaFricheParser(BaseCrawler):
 
         text_lower = text.lower()
 
-        # French month names mapping
-        months = {
-            "janvier": 1,
-            "février": 2,
-            "fevrier": 2,
-            "mars": 3,
-            "avril": 4,
-            "mai": 5,
-            "juin": 6,
-            "juillet": 7,
-            "août": 8,
-            "aout": 8,
-            "septembre": 9,
-            "octobre": 10,
-            "novembre": 11,
-            "décembre": 12,
-            "decembre": 12,
-        }
-
         # Pattern for single date with optional time: "27 janvier 2026 à 19h30"
         single_date_pattern = (
             r"(\d{1,2})\s+(\w+)\s+(\d{4})(?:\s+[àa]\s*(\d{1,2})h(\d{2})?)?"
@@ -249,7 +227,7 @@ class LaFricheParser(BaseCrawler):
             hour = int(match.group(4)) if match.group(4) else 20
             minute = int(match.group(5)) if match.group(5) else 0
 
-            month = months.get(month_name)
+            month = FRENCH_MONTHS.get(month_name)
             if month:
                 try:
                     return datetime(year, month, day, hour, minute, tzinfo=PARIS_TZ)
@@ -265,7 +243,7 @@ class LaFricheParser(BaseCrawler):
             month_name = match.group(2)
             year = int(match.group(3))
 
-            month = months.get(month_name)
+            month = FRENCH_MONTHS.get(month_name)
             if month:
                 try:
                     return datetime(year, month, day, 20, 0, tzinfo=PARIS_TZ)

--- a/crawler/src/parsers/lemakeda.py
+++ b/crawler/src/parsers/lemakeda.py
@@ -18,16 +18,14 @@ Strategy:
 import json
 import re
 from datetime import datetime
-from zoneinfo import ZoneInfo
 
 from ..crawler import BaseCrawler
 from ..logger import get_logger
 from ..models.event import Event
+from ..utils.french_date import PARIS_TZ
 from ..utils.parser import HTMLParser
 
 logger = get_logger(__name__)
-
-PARIS_TZ = ZoneInfo("Europe/Paris")
 
 # Tribe Events REST API endpoint
 TRIBE_API_BASE = "https://www.lemakeda.com/wp-json/tribe/events/v1"

--- a/crawler/src/parsers/lezef.py
+++ b/crawler/src/parsers/lezef.py
@@ -1,19 +1,16 @@
 """Parser for Le Zef - Scene nationale de Marseille events (lezef.org)."""
 
 import json
-import re
 from datetime import datetime
 from urllib.parse import urljoin
-from zoneinfo import ZoneInfo
 
 from ..crawler import BaseCrawler
 from ..logger import get_logger
 from ..models.event import Event
+from ..utils.french_date import PARIS_TZ, parse_french_time
 from ..utils.parser import HTMLParser
 
 logger = get_logger(__name__)
-
-PARIS_TZ = ZoneInfo("Europe/Paris")
 
 # AJAX endpoint for fetching event listings
 AJAX_URL = "https://www.lezef.org/fr/saison_ajax"
@@ -125,6 +122,7 @@ def _extract_time_from_html(html: str) -> tuple[int, int] | None:
     Extract event time from HTML date display.
 
     Le Zef shows times like "à 19h", "à 20h30", etc.
+    Delegates to shared parse_french_time utility.
 
     Args:
         html: HTML content of detail page
@@ -132,14 +130,7 @@ def _extract_time_from_html(html: str) -> tuple[int, int] | None:
     Returns:
         Tuple of (hour, minute) or None if not found
     """
-    # Pattern: "à 19h", "à 20h30", "à 19h00"
-    time_pattern = re.compile(r"à\s*(\d{1,2})h(\d{2})?", re.IGNORECASE)
-    match = time_pattern.search(html)
-    if match:
-        hour = int(match.group(1))
-        minute = int(match.group(2)) if match.group(2) else 0
-        return (hour, minute)
-    return None
+    return parse_french_time(html)
 
 
 def _generate_source_id(url: str) -> str:

--- a/crawler/src/parsers/shotgun.py
+++ b/crawler/src/parsers/shotgun.py
@@ -11,17 +11,15 @@ import re
 import time
 from datetime import datetime
 from urllib.parse import urlparse
-from zoneinfo import ZoneInfo
 
 from ..crawler import BaseCrawler
 from ..logger import get_logger
 from ..models.event import Event, slugify
 from ..models.venue import Venue
+from ..utils.french_date import FRENCH_MONTHS, PARIS_TZ
 from ..utils.parser import HTMLParser
 
 logger = get_logger(__name__)
-
-PARIS_TZ = ZoneInfo("Europe/Paris")
 
 # Maximum number of pages to crawl from the listing
 MAX_PAGES = 3
@@ -611,22 +609,8 @@ class ShotgunParser(BaseCrawler):
                 og_description.lower(),
             )
             if date_match:
-                months = {
-                    "janvier": 1,
-                    "février": 2,
-                    "mars": 3,
-                    "avril": 4,
-                    "mai": 5,
-                    "juin": 6,
-                    "juillet": 7,
-                    "août": 8,
-                    "septembre": 9,
-                    "octobre": 10,
-                    "novembre": 11,
-                    "décembre": 12,
-                }
                 day = int(date_match.group(1))
-                month = months.get(date_match.group(2))
+                month = FRENCH_MONTHS.get(date_match.group(2))
                 year = int(date_match.group(3))
                 if month:
                     try:

--- a/crawler/src/parsers/videodrome2.py
+++ b/crawler/src/parsers/videodrome2.py
@@ -4,35 +4,14 @@ import json
 import re
 from datetime import datetime
 from urllib.parse import urljoin
-from zoneinfo import ZoneInfo
 
 from ..crawler import BaseCrawler
 from ..logger import get_logger
 from ..models.event import Event
+from ..utils.french_date import FRENCH_MONTHS, PARIS_TZ
 from ..utils.parser import HTMLParser
 
 logger = get_logger(__name__)
-
-PARIS_TZ = ZoneInfo("Europe/Paris")
-
-# French month names mapping
-FRENCH_MONTHS = {
-    "janvier": 1,
-    "février": 2,
-    "fevrier": 2,
-    "mars": 3,
-    "avril": 4,
-    "mai": 5,
-    "juin": 6,
-    "juillet": 7,
-    "août": 8,
-    "aout": 8,
-    "septembre": 9,
-    "octobre": 10,
-    "novembre": 11,
-    "décembre": 12,
-    "decembre": 12,
-}
 
 BASE_URL = "https://www.videodrome2.fr"
 

--- a/crawler/src/utils/french_date.py
+++ b/crawler/src/utils/french_date.py
@@ -1,0 +1,365 @@
+"""French date and time parsing utilities.
+
+This module provides shared utilities for parsing French-formatted dates and times,
+commonly used across event parser implementations. Consolidating these utilities
+avoids code duplication and ensures consistent parsing behavior.
+
+Supported formats:
+- Single date: "27 janvier 2026", "27 janvier"
+- Date with time: "27 janvier 2026 à 19h30"
+- Date range: "Du 29 janvier au 7 février 2026"
+- Time formats: "19h", "19h30", "19:30"
+"""
+
+import re
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+# Paris timezone - standard for French events
+PARIS_TZ = ZoneInfo("Europe/Paris")
+
+# French month names to month numbers (1-12)
+# Includes both accented and non-accented variants
+FRENCH_MONTHS: dict[str, int] = {
+    "janvier": 1,
+    "février": 2,
+    "fevrier": 2,
+    "mars": 3,
+    "avril": 4,
+    "mai": 5,
+    "juin": 6,
+    "juillet": 7,
+    "août": 8,
+    "aout": 8,
+    "septembre": 9,
+    "octobre": 10,
+    "novembre": 11,
+    "décembre": 12,
+    "decembre": 12,
+}
+
+# French day names (lowercase) - for validation or display
+FRENCH_DAYS: dict[str, int] = {
+    "lundi": 0,
+    "mardi": 1,
+    "mercredi": 2,
+    "jeudi": 3,
+    "vendredi": 4,
+    "samedi": 5,
+    "dimanche": 6,
+}
+
+# Default event time when not specified (8 PM is common for evening events)
+DEFAULT_HOUR = 20
+DEFAULT_MINUTE = 0
+
+
+def parse_french_date(
+    text: str,
+    reference_year: int | None = None,
+    default_hour: int = DEFAULT_HOUR,
+    default_minute: int = DEFAULT_MINUTE,
+) -> datetime | None:
+    """
+    Parse a French date string into a datetime object.
+
+    Handles formats like:
+    - "27 janvier 2026" (full date)
+    - "27 janvier" (date without year, uses reference_year)
+    - "Mardi 27 janvier 2026" (with day name prefix)
+    - "27 janvier 2026 à 19h30" (with time)
+    - "Du 29 janvier au 7 février 2026" (range, returns start date)
+
+    Args:
+        text: French date string to parse
+        reference_year: Year to use if not specified in text (defaults to current year)
+        default_hour: Hour to use if no time is specified (default: 20)
+        default_minute: Minute to use if no time is specified (default: 0)
+
+    Returns:
+        datetime in Paris timezone, or None if parsing failed
+    """
+    if not text:
+        return None
+
+    if reference_year is None:
+        reference_year = datetime.now().year
+
+    text_lower = text.strip().lower()
+
+    # Try to extract time first
+    hour, minute = default_hour, default_minute
+    time_result = parse_french_time(text_lower)
+    if time_result:
+        hour, minute = time_result
+
+    # Pattern for date range: "Du DD mois au DD mois YYYY"
+    range_pattern = r"du\s+(\d{1,2})\s+(\w+)(?:\s+au\s+\d{1,2}\s+\w+)?\s+(\d{4})"
+    match = re.search(range_pattern, text_lower)
+    if match:
+        day = int(match.group(1))
+        month_name = match.group(2)
+        year = int(match.group(3))
+        month = FRENCH_MONTHS.get(month_name)
+        if month:
+            try:
+                return datetime(year, month, day, hour, minute, tzinfo=PARIS_TZ)
+            except ValueError:
+                pass
+
+    # Pattern for single date with year: "DD mois YYYY"
+    with_year_pattern = r"(\d{1,2})\s+(\w+)\s+(\d{4})"
+    match = re.search(with_year_pattern, text_lower)
+    if match:
+        day = int(match.group(1))
+        month_name = match.group(2)
+        year = int(match.group(3))
+        month = FRENCH_MONTHS.get(month_name)
+        if month:
+            try:
+                return datetime(year, month, day, hour, minute, tzinfo=PARIS_TZ)
+            except ValueError:
+                pass
+
+    # Pattern for single date without year: "DD mois"
+    without_year_pattern = r"(\d{1,2})\s+(\w+)\b"
+    match = re.search(without_year_pattern, text_lower)
+    if match:
+        day = int(match.group(1))
+        month_name = match.group(2)
+        month = FRENCH_MONTHS.get(month_name)
+        if month:
+            year = infer_year(month, day, reference_year)
+            try:
+                return datetime(year, month, day, hour, minute, tzinfo=PARIS_TZ)
+            except ValueError:
+                pass
+
+    return None
+
+
+def parse_french_time(text: str) -> tuple[int, int] | None:
+    """
+    Extract time from French time format.
+
+    Handles formats like:
+    - "19h" -> (19, 0)
+    - "19h30" -> (19, 30)
+    - "19H30" -> (19, 30)
+    - "19:30" -> (19, 30)
+    - "à 19h30" -> (19, 30)
+
+    Args:
+        text: Text containing a time
+
+    Returns:
+        Tuple of (hour, minute) or None if no time found
+    """
+    if not text:
+        return None
+
+    # Match "HHhMM" or "HHh" format (French style)
+    match = re.search(r"(\d{1,2})[hH](\d{2})?", text)
+    if match:
+        hour = int(match.group(1))
+        minute = int(match.group(2)) if match.group(2) else 0
+        if 0 <= hour <= 23 and 0 <= minute <= 59:
+            return (hour, minute)
+
+    # Match "HH:MM" format
+    match = re.search(r"\b(\d{1,2}):(\d{2})\b", text)
+    if match:
+        hour = int(match.group(1))
+        minute = int(match.group(2))
+        if 0 <= hour <= 23 and 0 <= minute <= 59:
+            return (hour, minute)
+
+    return None
+
+
+def parse_all_french_dates(
+    text: str,
+    reference_year: int | None = None,
+    default_hour: int = DEFAULT_HOUR,
+    default_minute: int = DEFAULT_MINUTE,
+) -> list[datetime]:
+    """
+    Parse a French date string and return ALL dates (for ranges and lists).
+
+    Handles formats:
+    - "30 janvier" -> [Jan 30]
+    - "Du 3 au 5 février" -> [Feb 3, Feb 4, Feb 5]
+    - "2, 3 et 5 février" -> [Feb 2, Feb 3, Feb 5]
+    - "23 et 24 janvier" -> [Jan 23, Jan 24]
+    - "Jusqu'au 31 janvier" -> [Jan 31]
+
+    Args:
+        text: French date string
+        reference_year: Year to use if not specified in text
+        default_hour: Hour to use if no time is specified
+        default_minute: Minute to use if no time is specified
+
+    Returns:
+        List of datetime objects (empty if parsing failed)
+    """
+    if not text:
+        return []
+
+    if reference_year is None:
+        reference_year = datetime.now().year
+
+    text_clean = text.strip().lower()
+
+    # Remove "a venir" prefix
+    text_clean = re.sub(r"^[àa]\s+venir\s*", "", text_clean).strip()
+
+    # Pattern: "Du DD au DD mois [YYYY]" - expand to all dates in range
+    range_match = re.search(
+        r"du\s+(\d{1,2})\s+(?:\w+\s+)?au\s+(\d{1,2})\s+(\w+)(?:\s+(\d{4}))?",
+        text_clean,
+    )
+    if range_match:
+        start_day = int(range_match.group(1))
+        end_day = int(range_match.group(2))
+        month_name = range_match.group(3)
+        year = int(range_match.group(4)) if range_match.group(4) else reference_year
+        month = FRENCH_MONTHS.get(month_name)
+        if month:
+            dates = []
+            for day in range(start_day, end_day + 1):
+                try:
+                    dates.append(
+                        datetime(
+                            year,
+                            month,
+                            day,
+                            default_hour,
+                            default_minute,
+                            tzinfo=PARIS_TZ,
+                        )
+                    )
+                except ValueError:
+                    pass
+            if dates:
+                return dates
+
+    # Pattern: "DD, DD et DD mois [YYYY]" (list with commas and 'et')
+    list_match = re.search(
+        r"((?:\d{1,2}\s*,\s*)*\d{1,2})\s+et\s+(\d{1,2})\s+(\w+)(?:\s+(\d{4}))?",
+        text_clean,
+    )
+    if list_match:
+        days_before_et = list_match.group(1)
+        last_day = int(list_match.group(2))
+        month_name = list_match.group(3)
+        year = int(list_match.group(4)) if list_match.group(4) else reference_year
+        month = FRENCH_MONTHS.get(month_name)
+        if month:
+            dates = []
+            # Parse all days before 'et'
+            for day_str in re.findall(r"\d{1,2}", days_before_et):
+                try:
+                    dates.append(
+                        datetime(
+                            year,
+                            month,
+                            int(day_str),
+                            default_hour,
+                            default_minute,
+                            tzinfo=PARIS_TZ,
+                        )
+                    )
+                except ValueError:
+                    pass
+            # Add the day after 'et'
+            try:
+                dates.append(
+                    datetime(
+                        year,
+                        month,
+                        last_day,
+                        default_hour,
+                        default_minute,
+                        tzinfo=PARIS_TZ,
+                    )
+                )
+            except ValueError:
+                pass
+            if dates:
+                return dates
+
+    # Pattern: "Jusqu'au DD mois [YYYY]"
+    jusquau_match = re.search(
+        r"jusqu[''']?\s*au\s+(\d{1,2})\s+(\w+)(?:\s+(\d{4}))?",
+        text_clean,
+    )
+    if jusquau_match:
+        day = int(jusquau_match.group(1))
+        month_name = jusquau_match.group(2)
+        year = int(jusquau_match.group(3)) if jusquau_match.group(3) else reference_year
+        month = FRENCH_MONTHS.get(month_name)
+        if month:
+            try:
+                return [
+                    datetime(
+                        year, month, day, default_hour, default_minute, tzinfo=PARIS_TZ
+                    )
+                ]
+            except ValueError:
+                pass
+
+    # Fallback: single date
+    single = parse_french_date(text, reference_year, default_hour, default_minute)
+    if single:
+        return [single]
+
+    return []
+
+
+def infer_year(month: int, day: int, reference_year: int | None = None) -> int:
+    """
+    Infer the year for a date without year specification.
+
+    If the date has already passed this year (by more than 30 days),
+    assumes next year.
+
+    Args:
+        month: Month number (1-12)
+        day: Day of month
+        reference_year: Reference year (defaults to current year)
+
+    Returns:
+        Inferred year
+    """
+    if reference_year is None:
+        reference_year = datetime.now().year
+
+    now = datetime.now(PARIS_TZ)
+    try:
+        candidate = datetime(reference_year, month, day, tzinfo=PARIS_TZ)
+    except ValueError:
+        return reference_year
+
+    # If date is more than 30 days in the past, assume next year
+    if (now - candidate).days > 30:
+        return reference_year + 1
+    return reference_year
+
+
+def format_french_date(dt: datetime) -> str:
+    """
+    Format a datetime as a French date string.
+
+    Args:
+        dt: datetime to format
+
+    Returns:
+        French date string like "27 janvier 2026"
+    """
+    # Reverse lookup for month name
+    month_names = {
+        v: k for k, v in FRENCH_MONTHS.items() if "é" in k or "û" in k or len(k) > 4
+    }
+    # Use accented versions when available
+    month_name = month_names.get(dt.month, list(FRENCH_MONTHS.keys())[dt.month - 1])
+    return f"{dt.day} {month_name} {dt.year}"

--- a/crawler/tests/test_videodrome2_parser.py
+++ b/crawler/tests/test_videodrome2_parser.py
@@ -100,8 +100,8 @@ def sample_detail_html():
                 {
                     "@type": "event",
                     "name": "Cine-club LSF | Les Sourds en colere de Jacques Sangla",
-                    "startDate": "2026-02-03T08:30:00+01:00",
-                    "endDate": "2026-02-03T09:15:00+01:00",
+                    "startDate": "2026-03-03T08:30:00+01:00",
+                    "endDate": "2026-03-03T09:15:00+01:00",
                     "eventStatus": "EventScheduled",
                     "eventAttendanceMode": "OfflineEventAttendanceMode"
                 }
@@ -112,7 +112,7 @@ def sample_detail_html():
     <body>
         <h1>Cine-club LSF | Les Sourds en colere de Jacques Sangla</h1>
         <div class="entry-content">
-            <p>mardi 3 fevrier 2026 de 20h30 a 21h15</p>
+            <p>mardi 3 mars 2026 de 20h30 a 21h15</p>
             <p>Les Sourds en colere de Jacques Sangla | 2022 | France | 52 min</p>
             <p>Dans le cadre des 20 ans du programme PiSourd, le cine-club LSF
                propose la projection du film Les Sourds en colere suivi d'un
@@ -426,11 +426,11 @@ class TestParseFrenchDatetime:
 
     def test_parses_full_datetime_with_de(self):
         result = _parse_french_datetime_from_text(
-            "mardi 3 fevrier 2026 de 20h30 a 21h15"
+            "mardi 3 mars 2026 de 20h30 a 21h15"
         )
         assert result is not None
         assert result.year == 2026
-        assert result.month == 2
+        assert result.month == 3
         assert result.day == 3
         assert result.hour == 20
         assert result.minute == 30
@@ -495,7 +495,7 @@ class TestParseFrenchDatetime:
 
     def test_has_paris_timezone(self):
         result = _parse_french_datetime_from_text(
-            "3 fevrier 2026 · 20h30"
+            "3 mars 2026 · 20h30"
         )
         assert result is not None
         assert result.tzinfo == PARIS_TZ
@@ -656,7 +656,7 @@ class TestParseDetailPage:
     def test_returns_none_without_name(self, parser):
         html = """
         <html><body>
-            <p>mardi 3 fevrier 2026 de 20h30</p>
+            <p>mardi 3 mars 2026 de 20h30</p>
         </body></html>
         """
         parser.http_client.get_text.return_value = html
@@ -694,7 +694,7 @@ class TestCategoryExtraction:
         ]}
         </script>
         </head><body><h1>Test</h1>
-        <p>3 fevrier 2026 · 20h00</p></body></html>
+        <p>3 mars 2026 · 20h00</p></body></html>
         """
         parser.http_client.get_text.return_value = html
         event = parser._parse_detail_page("https://www.videodrome2.fr/test/")
@@ -710,7 +710,7 @@ class TestCategoryExtraction:
         ]}
         </script>
         </head><body><h1>Test</h1>
-        <p>3 fevrier 2026 · 14h00</p></body></html>
+        <p>3 mars 2026 · 14h00</p></body></html>
         """
         parser.http_client.get_text.return_value = html
         event = parser._parse_detail_page("https://www.videodrome2.fr/test/")
@@ -721,7 +721,7 @@ class TestCategoryExtraction:
         html = """
         <html><head></head><body>
             <h1>Test Event</h1>
-            <p>3 fevrier 2026 · 20h00</p>
+            <p>3 mars 2026 · 20h00</p>
         </body></html>
         """
         parser.http_client.get_text.return_value = html


### PR DESCRIPTION
## Summary
- Extracts duplicated French date parsing logic into a new `crawler/src/utils/french_date.py` module
- Consolidates `PARIS_TZ` timezone constant used across 10+ parsers into a single location
- Provides reusable `parse_french_date()` and `parse_french_time()` functions with comprehensive month/day name handling

## Test plan
- [ ] Run `pytest` to verify all existing tests pass
- [ ] Run `python crawl.py run --dry-run` to verify crawlers still parse dates correctly
- [ ] Spot-check a few sources with `python crawl.py run --source <name> --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)