### PR TITLE
Add URL validation to prevent SSRF in crawler

### DIFF
--- a/crawler/src/utils/images.py
+++ b/crawler/src/utils/images.py
@@ -141,6 +141,9 @@ class ImageDownloader:
             else:
                 import httpx
 
+                from .http import validate_url
+
+                validate_url(url)
                 response = httpx.get(url, timeout=30, follow_redirects=True)
                 response.raise_for_status()
                 image_bytes = response.content


### PR DESCRIPTION
## Summary

Closes #103

- Add `validate_url()` function in `crawler/src/utils/http.py` that rejects non-HTTP(S) schemes, private/reserved IP ranges (127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), link-local/metadata IPs (169.254.0.0/16), IPv6 loopback (::1), and localhost hostnames
- Apply validation as centralized chokepoint in `HTTPClient.fetch()` and `HTTPClient.get()` before any network request
- Apply validation in `ImageDownloader.download()` fallback path (bare `httpx.get()`)
- Add custom `SSRFError` exception (subclass of `ValueError`) for clear error handling
- Log rejected URLs at WARNING level for monitoring

## Test plan

- [x] 30 new unit tests covering all validation cases:
  - External URLs pass through (venue URLs, paths, ports)
  - Private IPs rejected (127.x, 10.x, 172.16.x, 192.168.x)
  - Link-local/cloud metadata IPs rejected (169.254.169.254)
  - IPv6 loopback rejected (::1)
  - Non-HTTP schemes rejected (file://, ftp://, data:, javascript:)
  - Localhost hostnames rejected
  - HTTPClient integration tests (fetch returns error, get/get_text/get_bytes raise)
- [x] Full test suite: 946 passed, 1 pre-existing failure (videodrome2 — unrelated)
- [x] `ruff check` passes

🤖 Generated with [Claude Code](https://claude.ai/code)